### PR TITLE
Feature 5520/Remove invalidation when alignment completed

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,9 @@
     "react/no-unescaped-entities": "warn",
     "react/no-find-dom-node": "warn",
     "semi": ["error", "always", {"omitLastInOneLineBlock": true}],
-    "no-console": "off"
+    "no-console": "off",
+    "no-async-promise-executor":"off",
+    "import/order":"warn"
   },
   "parser": "babel-eslint",
   "parserOptions": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -20,8 +20,7 @@
     "react/no-find-dom-node": "warn",
     "semi": ["error", "always", {"omitLastInOneLineBlock": true}],
     "no-console": "off",
-    "no-async-promise-executor":"off",
-    "import/order":"warn"
+    "no-async-promise-executor":"off"
   },
   "parser": "babel-eslint",
   "parserOptions": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "display": "app",
   "scripts": {
-    "test": "eslint ./src && jest ./src"
+    "test": "eslint ./src && jest ./src",
+    "lint-fix": "eslint ./src --fix"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/src/Api.js
+++ b/src/Api.js
@@ -1,5 +1,8 @@
 import {getActiveLanguage, setActiveLocale, ToolApi} from 'tc-tool';
 import isEqual from 'deep-equal';
+import path from 'path-extra';
+import Lexer, {Token} from 'wordmap-lexer';
+import {Alignment, Ngram} from 'wordmap';
 import {
   getGroupMenuItem,
   getIsChapterLoaded,
@@ -9,9 +12,6 @@ import {
   getVerseAlignedTargetTokens,
   getVerseAlignments
 } from './state/reducers';
-import path from 'path-extra';
-import Lexer, {Token} from 'wordmap-lexer';
-import {Alignment, Ngram} from 'wordmap';
 import {tokenizeVerseObjects} from './utils/verseObjects';
 import {removeUsfmMarkers} from './utils/usfmHelpers';
 import {

--- a/src/Api.js
+++ b/src/Api.js
@@ -677,6 +677,8 @@ export default class Api extends ToolApi {
     }
     const dataPath = path.join('completed', chapter + '', verse + '.json');
     if (finished) {
+      this.setVerseInvalid(chapter, verse, false); // reset invalidated flag if finished
+
       const data = {
         username,
         modifiedTimestamp: (new Date()).toJSON()

--- a/src/__tests__/api.js
+++ b/src/__tests__/api.js
@@ -1,9 +1,9 @@
-jest.mock('../state/reducers');
-jest.mock('../state/actions');
 import * as _ from 'lodash';
 import * as reducers from '../state/reducers';
 import * as actions from '../state/actions';
 import Api from '../Api';
+jest.mock('../state/reducers');
+jest.mock('../state/actions');
 
 const saveConsole = global.console;
 
@@ -307,12 +307,14 @@ describe('verse finished', () => {
     const writeToolData = jest.fn(() => Promise.resolve());
     const deleteToolFile = jest.fn(() => Promise.resolve());
     const recordCheck = jest.fn();
+    const toolDataPathExists = jest.fn(() => Promise.resolve(false));
 
     api.props = {
       recordCheck,
       tool: {
         writeToolData,
         deleteToolFile,
+        toolDataPathExists,
       },
       tc: {
         username: 'username',

--- a/src/components/AlignmentCard/__tests__/AlignmentCard.test.js
+++ b/src/components/AlignmentCard/__tests__/AlignmentCard.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import AlignmentCard from '../AlignmentCard';
 import TestBackend from 'react-dnd-test-backend';
 import {DragDropContext} from 'react-dnd';
+import AlignmentCard from '../AlignmentCard';
 import WordCard from '../../WordCard';
 
 const singleTopWord = [

--- a/src/components/AlignmentCard/index.js
+++ b/src/components/AlignmentCard/index.js
@@ -1,11 +1,11 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {DropTarget} from 'react-dnd';
+import {Token} from 'wordmap-lexer';
 import * as types from '../WordCard/Types';
 import SecondaryToken from '../SecondaryToken';
 import PrimaryToken from '../PrimaryToken';
 import AlignmentCard from './AlignmentCard';
-import {Token} from 'wordmap-lexer';
 
 const styles = {
   root: {
@@ -51,7 +51,7 @@ export const canDropPrimaryToken = (dropTargetProps, dragSourceProps) => {
   if(singleSource && mergedTarget) {
     return true;
   }
-  
+
   if(mergedSource) { // removing a word from a merged group
     if (emptyTarget) { // moving word from merged group to empty (unmerge)
       if (!different) { // if unmerge target for this group
@@ -62,7 +62,7 @@ export const canDropPrimaryToken = (dropTargetProps, dragSourceProps) => {
     } else if (mergedTarget && different) { //  moving word from merged group to a different merged group
       return true;
     }
-    
+
     // TODO: need a workaround for this bug before supporting left vs right un-merging https://github.com/react-dnd/react-dnd/issues/735
     // see components/AlignmentGrid.js
     // we could potentially use the touch backend https://github.com/yahoo/react-dnd-touch-backend

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -2,13 +2,13 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {DragDropContext} from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
-import WordList from './WordList/index';
-import AlignmentGrid from './AlignmentGrid';
 import isEqual from 'deep-equal';
 import WordMap, {Alignment, Ngram} from 'wordmap';
 import Lexer, {Token} from 'wordmap-lexer';
 import Snackbar from 'material-ui/Snackbar';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import {connect} from 'react-redux';
+import {batchActions} from 'redux-batched-actions';
 import {
   acceptAlignmentSuggestions,
   acceptTokenSuggestion,
@@ -29,16 +29,16 @@ import {
   getRenderedVerseAlignments,
   getVerseHasRenderedSuggestions
 } from '../state/reducers';
-import {connect} from 'react-redux';
 import {tokenizeVerseObjects} from '../utils/verseObjects';
 import {sortPanesSettings} from '../utils/panesSettingsHelper';
 import {removeUsfmMarkers} from '../utils/usfmHelpers';
-import MAPControls from './MAPControls';
 import GroupMenuContainer from '../containers/GroupMenuContainer';
 import ScripturePaneContainer from '../containers/ScripturePaneContainer';
-import MissingBibleError from './MissingBibleError';
 import Api from '../Api';
-import {batchActions} from 'redux-batched-actions';
+import MAPControls from './MAPControls';
+import MissingBibleError from './MissingBibleError';
+import AlignmentGrid from './AlignmentGrid';
+import WordList from './WordList/index';
 
 const styles = {
   container: {

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -235,19 +235,6 @@ class Container extends Component {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    const {
-      tc: {
-        contextId: nextContextId
-      },
-      tool: {
-        api
-      }
-    } = nextProps;
-
-    const {reference: {chapter, verse}} = nextContextId;
-
-    api.setVerseInvalid(chapter, verse, false);
-
     if (Container.contextDidChange(nextProps, this.props)) {
       // scroll alignments to top when context changes
       let page = document.getElementById('AlignmentGrid');

--- a/src/components/PrimaryToken.js
+++ b/src/components/PrimaryToken.js
@@ -2,10 +2,10 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {DragSource} from 'react-dnd';
 import { WordLexiconDetails, lexiconHelpers } from 'tc-ui-toolkit';
+import {Token} from 'wordmap-lexer';
 import * as types from './WordCard/Types';
 // components
 import Word from './WordCard';
-import {Token} from 'wordmap-lexer';
 
 const internalStyle = {
   word: {

--- a/src/components/SecondaryToken.js
+++ b/src/components/SecondaryToken.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Word from './WordCard';
 import {DragSource} from 'react-dnd';
-import * as types from './WordCard/Types';
 import {Token} from 'wordmap-lexer';
 import path from 'path-extra';
+import * as types from './WordCard/Types';
+import Word from './WordCard';
 
 /**
  * Checks if a token exists within the list

--- a/src/components/WordList/WordList.js
+++ b/src/components/WordList/WordList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import SecondaryToken from '../SecondaryToken';
 import {Token} from 'wordmap-lexer';
+import SecondaryToken from '../SecondaryToken';
 
 /**
  * Renders a list of words that need to be aligned.

--- a/src/components/WordList/__tests__/DroppableWordList.test.js
+++ b/src/components/WordList/__tests__/DroppableWordList.test.js
@@ -3,9 +3,9 @@ import {Token} from 'wordmap-lexer';
 import React, {Component} from 'react';
 import TestBackend from 'react-dnd-test-backend';
 import {DragDropContext} from 'react-dnd';
-import DroppableWordList from '../index';
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
+import DroppableWordList from '../index';
 
 describe('Test DroppableWordList component in WordList/index.js', () => {
   let props;

--- a/src/components/WordList/__tests__/WordList.test.js
+++ b/src/components/WordList/__tests__/WordList.test.js
@@ -4,8 +4,8 @@ import {Token} from 'wordmap-lexer';
 import React, {Component} from 'react';
 import TestBackend from 'react-dnd-test-backend';
 import {DragDropContext} from 'react-dnd';
-import WordList from '../WordList';
 import renderer from 'react-test-renderer';
+import WordList from '../WordList';
 
 describe('snapshot', () => {
   it('has no words', () => {

--- a/src/components/WordList/index.js
+++ b/src/components/WordList/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {DropTarget} from 'react-dnd';
+import {Token} from 'wordmap-lexer';
 import * as types from '../WordCard/Types';
 import WordList from './WordList';
-import {Token} from 'wordmap-lexer';
 
 /**
  * Renders a word bank with drag-drop support

--- a/src/components/__tests__/AlignmentGrid.test.js
+++ b/src/components/__tests__/AlignmentGrid.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import AlignmentGrid from '../AlignmentGrid';
 import renderer from 'react-test-renderer';
 import {shallow} from 'enzyme';
 import TestBackend from 'react-dnd-test-backend';
 import {DragDropContext} from 'react-dnd';
 import {Token} from 'wordmap-lexer';
+import AlignmentGrid from '../AlignmentGrid';
 
 test('empty snapshot', () => {
   const wrapper = renderer.create(

--- a/src/components/__tests__/MAPControls.test.js
+++ b/src/components/__tests__/MAPControls.test.js
@@ -1,7 +1,7 @@
-import MAPControls from '../MAPControls';
 import React from 'react';
 import {shallow} from 'enzyme';
 import toJson from 'enzyme-to-json';
+import MAPControls from '../MAPControls';
 
 describe('MAPControls', () => {
   it('renders', () => {

--- a/src/containers/GroupMenuContainer.js
+++ b/src/containers/GroupMenuContainer.js
@@ -2,14 +2,14 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {GroupedMenu, generateMenuData, generateMenuItem, InvalidatedIcon, CheckIcon} from 'tc-ui-toolkit';
 import PropTypes from 'prop-types';
-import Api from '../Api';
-import {getChecks} from '../state/reducers';
 
 import BookmarkIcon from '@material-ui/icons/Bookmark';
 import BlockIcon from '@material-ui/icons/Block';
 import ModeCommentIcon from '@material-ui/icons/ModeComment';
 import EditIcon from '@material-ui/icons/Edit';
 import UnalignedIcon from '@material-ui/icons/RemoveCircle';
+import {getChecks} from '../state/reducers';
+import Api from '../Api';
 import {EDITED_KEY, FINISHED_KEY, INVALID_KEY, UNALIGNED_KEY} from "../state/reducers/groupMenu";
 
 class GroupMenuContainer extends React.Component {

--- a/src/state/actions/__tests__/actions.test.js
+++ b/src/state/actions/__tests__/actions.test.js
@@ -1,9 +1,9 @@
 import _ from "lodash";
-import * as actions from '../index';
 import {Token} from 'wordmap-lexer';
 import {Prediction, Alignment, Ngram} from 'wordmap';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import * as actions from '../index';
 import {
   ALIGN_RENDERED_SOURCE_TOKEN,
   INSERT_RENDERED_ALIGNMENT,

--- a/src/state/actions/__tests__/mocked.actions.test.js
+++ b/src/state/actions/__tests__/mocked.actions.test.js
@@ -1,9 +1,9 @@
-jest.mock('../../reducers');
-jest.mock('../../../utils/alignmentValidation');
+import {Token} from 'wordmap-lexer';
 import {areAlignmentsEquivalent} from '../../../utils/alignmentValidation';
 import * as reducers from '../../reducers';
 import * as actions from '../index';
-import {Token} from 'wordmap-lexer';
+jest.mock('../../reducers');
+jest.mock('../../../utils/alignmentValidation');
 
 describe('repair and inspect verse', () => {
 

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -1,10 +1,10 @@
-import * as types from './actionTypes';
-import {migrateChapterAlignments} from '../../utils/migrations';
 import Lexer from 'wordmap-lexer';
+import {migrateChapterAlignments} from '../../utils/migrations';
 import {tokenizeVerseObjects} from '../../utils/verseObjects';
 import {removeUsfmMarkers} from '../../utils/usfmHelpers';
 import {getVerseAlignments, getRenderedVerseAlignments} from '../reducers';
 import {areAlignmentsEquivalent} from '../../utils/alignmentValidation';
+import * as types from './actionTypes';
 
 /**
  * Puts alignment data that has been loaded from the file system into redux.

--- a/src/state/reducers/__mocks__/index.js
+++ b/src/state/reducers/__mocks__/index.js
@@ -17,7 +17,7 @@ const reducers = jest.genMockFromModule('../');
 // mock getIsVerseAligned
 {
   let isVerseAligned = {};
-  
+
   function __setIsVerseAligned(chapter, verse, aligned) {
     if(!isVerseAligned.hasOwnProperty(chapter)) {
       isVerseAligned[chapter] = {};
@@ -27,7 +27,7 @@ const reducers = jest.genMockFromModule('../');
     }
     isVerseAligned[chapter][verse] = aligned;
   }
-  
+
   reducers.__setIsVerseAligned = __setIsVerseAligned;
   reducers.getIsVerseAligned = jest.fn((state, chapter, verse) => {
     if(isVerseAligned.hasOwnProperty(chapter) && isVerseAligned[chapter].hasOwnProperty(verse)) {

--- a/src/state/reducers/alignments/__tests__/alignments.test.js
+++ b/src/state/reducers/alignments/__tests__/alignments.test.js
@@ -1,8 +1,8 @@
-import * as types from '../../../actions/actionTypes';
-import alignments, * as fromAlignments from '../index';
 import {Token} from 'wordmap-lexer';
 import _ from "lodash";
 import deepFreeze from 'deep-freeze';
+import alignments, * as fromAlignments from '../index';
+import * as types from '../../../actions/actionTypes';
 
 describe('set chapter alignments when empty', () => {
   const stateBefore = {};

--- a/src/state/reducers/alignments/__tests__/suggestions.test.js
+++ b/src/state/reducers/alignments/__tests__/suggestions.test.js
@@ -1,7 +1,7 @@
-import {reducerTest} from './alignments.test';
+import {Token} from 'wordmap-lexer';
 import * as types from '../../../actions/actionTypes';
 import alignments from '../index';
-import {Token} from 'wordmap-lexer';
+import {reducerTest} from './alignments.test';
 
 describe('set alignment suggestions', () => {
   const stateBefore = {

--- a/src/state/reducers/alignments/alignment.js
+++ b/src/state/reducers/alignments/alignment.js
@@ -1,3 +1,5 @@
+import {Token} from 'wordmap-lexer';
+import _ from 'lodash';
 import {
   ACCEPT_TOKEN_SUGGESTION,
   INSERT_RENDERED_ALIGNMENT,
@@ -6,8 +8,6 @@ import {
   SET_CHAPTER_ALIGNMENTS
 } from '../../actions/actionTypes';
 import {numberComparator} from './index';
-import {Token} from 'wordmap-lexer';
-import _ from 'lodash';
 
 const defaultState = {sourceNgram: [], targetNgram: []};
 

--- a/src/state/reducers/alignments/index.js
+++ b/src/state/reducers/alignments/index.js
@@ -1,5 +1,3 @@
-import chapter, * as fromChapter from './chapter';
-
 import {
   ACCEPT_TOKEN_SUGGESTION,
   ACCEPT_VERSE_ALIGNMENT_SUGGESTIONS,
@@ -18,6 +16,8 @@ import {
   UNALIGN_RENDERED_SOURCE_TOKEN,
   UNALIGN_RENDERED_TARGET_TOKEN
 } from '../../actions/actionTypes';
+import chapter, * as fromChapter from './chapter';
+
 
 /**
  * Compares two numbers for sorting

--- a/src/state/reducers/alignments/renderedAlignments.js
+++ b/src/state/reducers/alignments/renderedAlignments.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+import {Token} from 'wordmap-lexer';
 import {
   ACCEPT_TOKEN_SUGGESTION,
   ACCEPT_VERSE_ALIGNMENT_SUGGESTIONS,
@@ -9,8 +11,6 @@ import {
   SET_ALIGNMENT_SUGGESTIONS,
   SET_CHAPTER_ALIGNMENTS
 } from '../../actions/actionTypes';
-import _ from 'lodash';
-import {Token} from 'wordmap-lexer';
 import render, {convertToRendered} from './render';
 
 /**

--- a/src/state/reducers/alignments/verse.js
+++ b/src/state/reducers/alignments/verse.js
@@ -1,3 +1,6 @@
+import {Token} from 'wordmap-lexer';
+import _ from 'lodash';
+import {insertSourceToken} from '../../actions';
 import {
   ACCEPT_TOKEN_SUGGESTION,
   ACCEPT_VERSE_ALIGNMENT_SUGGESTIONS,
@@ -15,17 +18,14 @@ import {
   UNALIGN_RENDERED_SOURCE_TOKEN,
   UNALIGN_RENDERED_TARGET_TOKEN
 } from '../../actions/actionTypes';
-import alignmentReducer, * as fromAlignment from './alignment';
-import {Token} from 'wordmap-lexer';
-import {numberComparator} from './index';
-import {insertSourceToken} from '../../actions';
 import renderedAlignmentsReducer, * as fromRenderedAlignments
   from './renderedAlignments';
 import renderedAlignmentReducer, * as fromRenderedAlignment
   from './renderedAlignment';
-import _ from 'lodash';
+import alignmentReducer, * as fromAlignment from './alignment';
 import suggestionReducer from './suggestion';
 import compile from './compile';
+import {numberComparator} from './index';
 
 /**
  * Compares two alignments for sorting


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- make change so that invalidation is not reset when you navigate to verse, but when you either complete the alignments or when you toggle alignment complete.

#### Please include detailed Test instructions for your pull request:
- use the test build below.  You can use this project that has a lot of invalidations: https://git.door43.org/photonomad1/en_prct_tit_book
- import and launch wa tool.
- pick an invalidated verse, when you switch to it you should not see invalidation clear.
- toggle alignment complete and you should see invalidation clear
- pick another invalidated verse.  Click on the accept button for suggested alignments.  Now Drag unaligned words until alignment is complete.  You should see alignment complete check come on and invalidation flag clear at the same time.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)
