### PR TITLE
Feature 5440/Make WordBank variable width

### DIFF
--- a/src/components/AlignmentCard/__tests__/__snapshots__/AlignmentCard.test.js.snap
+++ b/src/components/AlignmentCard/__tests__/__snapshots__/AlignmentCard.test.js.snap
@@ -97,6 +97,7 @@ exports[`has a bottom word 1`] = `
                 Object {
                   "display": "flex",
                   "flex": 1,
+                  "overflow": "hidden",
                 }
               }
             >
@@ -105,6 +106,8 @@ exports[`has a bottom word 1`] = `
                 style={
                   Object {
                     "flexGrow": 2,
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
                     "width": "max-content",
                   }
                 }
@@ -202,6 +205,7 @@ exports[`has a top and bottom word 1`] = `
                 Object {
                   "display": "flex",
                   "flex": 1,
+                  "overflow": "hidden",
                 }
               }
             >
@@ -210,6 +214,8 @@ exports[`has a top and bottom word 1`] = `
                 style={
                   Object {
                     "flexGrow": 2,
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
                     "width": "max-content",
                   }
                 }
@@ -271,6 +277,7 @@ exports[`has a top and bottom word 1`] = `
                 Object {
                   "display": "flex",
                   "flex": 1,
+                  "overflow": "hidden",
                 }
               }
             >
@@ -279,6 +286,8 @@ exports[`has a top and bottom word 1`] = `
                 style={
                   Object {
                     "flexGrow": 2,
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
                     "width": "max-content",
                   }
                 }
@@ -376,6 +385,7 @@ exports[`has a top word 1`] = `
                 Object {
                   "display": "flex",
                   "flex": 1,
+                  "overflow": "hidden",
                 }
               }
             >
@@ -384,6 +394,8 @@ exports[`has a top word 1`] = `
                 style={
                   Object {
                     "flexGrow": 2,
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
                     "width": "max-content",
                   }
                 }
@@ -522,6 +534,7 @@ exports[`has multiple bottom words 1`] = `
                 Object {
                   "display": "flex",
                   "flex": 1,
+                  "overflow": "hidden",
                 }
               }
             >
@@ -530,6 +543,8 @@ exports[`has multiple bottom words 1`] = `
                 style={
                   Object {
                     "flexGrow": 2,
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
                     "width": "max-content",
                   }
                 }
@@ -564,6 +579,7 @@ exports[`has multiple bottom words 1`] = `
                 Object {
                   "display": "flex",
                   "flex": 1,
+                  "overflow": "hidden",
                 }
               }
             >
@@ -572,6 +588,8 @@ exports[`has multiple bottom words 1`] = `
                 style={
                   Object {
                     "flexGrow": 2,
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
                     "width": "max-content",
                   }
                 }
@@ -669,6 +687,7 @@ exports[`has multiple top and bottom words 1`] = `
                 Object {
                   "display": "flex",
                   "flex": 1,
+                  "overflow": "hidden",
                 }
               }
             >
@@ -677,6 +696,8 @@ exports[`has multiple top and bottom words 1`] = `
                 style={
                   Object {
                     "flexGrow": 2,
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
                     "width": "max-content",
                   }
                 }
@@ -711,6 +732,7 @@ exports[`has multiple top and bottom words 1`] = `
                 Object {
                   "display": "flex",
                   "flex": 1,
+                  "overflow": "hidden",
                 }
               }
             >
@@ -719,6 +741,8 @@ exports[`has multiple top and bottom words 1`] = `
                 style={
                   Object {
                     "flexGrow": 2,
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
                     "width": "max-content",
                   }
                 }
@@ -780,6 +804,7 @@ exports[`has multiple top and bottom words 1`] = `
                 Object {
                   "display": "flex",
                   "flex": 1,
+                  "overflow": "hidden",
                 }
               }
             >
@@ -788,6 +813,8 @@ exports[`has multiple top and bottom words 1`] = `
                 style={
                   Object {
                     "flexGrow": 2,
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
                     "width": "max-content",
                   }
                 }
@@ -822,6 +849,7 @@ exports[`has multiple top and bottom words 1`] = `
                 Object {
                   "display": "flex",
                   "flex": 1,
+                  "overflow": "hidden",
                 }
               }
             >
@@ -830,6 +858,8 @@ exports[`has multiple top and bottom words 1`] = `
                 style={
                   Object {
                     "flexGrow": 2,
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
                     "width": "max-content",
                   }
                 }
@@ -927,6 +957,7 @@ exports[`has multiple top words 1`] = `
                 Object {
                   "display": "flex",
                   "flex": 1,
+                  "overflow": "hidden",
                 }
               }
             >
@@ -935,6 +966,8 @@ exports[`has multiple top words 1`] = `
                 style={
                   Object {
                     "flexGrow": 2,
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
                     "width": "max-content",
                   }
                 }
@@ -969,6 +1002,7 @@ exports[`has multiple top words 1`] = `
                 Object {
                   "display": "flex",
                   "flex": 1,
+                  "overflow": "hidden",
                 }
               }
             >
@@ -977,6 +1011,8 @@ exports[`has multiple top words 1`] = `
                 style={
                   Object {
                     "flexGrow": 2,
+                    "overflow": "hidden",
+                    "textOverflow": "ellipsis",
                     "width": "max-content",
                   }
                 }

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -52,14 +52,15 @@ const styles = {
     height: '100%'
   },
   wordListContainer: {
-    minWidth: '120px',
-    maxWidth: '260px',
+    minWidth: '100px',
+    maxWidth: '400px',
     height: '100%'
   },
   alignmentAreaContainer: {
     display: 'flex',
     flex: 1,
     flexDirection: 'column',
+    width: 'calc(100vw - 650px)',
     height: '100%'
   },
   scripturePaneWrapper: {

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -52,14 +52,14 @@ const styles = {
     height: '100%'
   },
   wordListContainer: {
-    width: '160px',
+    minWidth: '120px',
+    maxWidth: '260px',
     height: '100%'
   },
   alignmentAreaContainer: {
     display: 'flex',
     flex: 1,
     flexDirection: 'column',
-    width: 'calc(100vw - 410px)',
     height: '100%'
   },
   scripturePaneWrapper: {

--- a/src/components/WordCard/__tests__/__snapshots__/WordCard.test.js.snap
+++ b/src/components/WordCard/__tests__/__snapshots__/WordCard.test.js.snap
@@ -26,6 +26,7 @@ exports[`is a suggestion 1`] = `
         Object {
           "display": "flex",
           "flex": 1,
+          "overflow": "hidden",
         }
       }
     >
@@ -34,6 +35,8 @@ exports[`is a suggestion 1`] = `
         style={
           Object {
             "flexGrow": 2,
+            "overflow": "hidden",
+            "textOverflow": "ellipsis",
             "width": "max-content",
           }
         }
@@ -109,6 +112,7 @@ exports[`occurs multiple times 1`] = `
         Object {
           "display": "flex",
           "flex": 1,
+          "overflow": "hidden",
         }
       }
     >
@@ -117,6 +121,8 @@ exports[`occurs multiple times 1`] = `
         style={
           Object {
             "flexGrow": 2,
+            "overflow": "hidden",
+            "textOverflow": "ellipsis",
             "width": "max-content",
           }
         }
@@ -165,6 +171,7 @@ exports[`occurs once 1`] = `
         Object {
           "display": "flex",
           "flex": 1,
+          "overflow": "hidden",
         }
       }
     >
@@ -173,6 +180,8 @@ exports[`occurs once 1`] = `
         style={
           Object {
             "flexGrow": 2,
+            "overflow": "hidden",
+            "textOverflow": "ellipsis",
             "width": "max-content",
           }
         }
@@ -210,6 +219,7 @@ exports[`renders rtl 1`] = `
         Object {
           "display": "flex",
           "flex": 1,
+          "overflow": "hidden",
         }
       }
     >
@@ -218,6 +228,8 @@ exports[`renders rtl 1`] = `
         style={
           Object {
             "flexGrow": 2,
+            "overflow": "hidden",
+            "textOverflow": "ellipsis",
             "width": "max-content",
           }
         }

--- a/src/components/WordCard/index.js
+++ b/src/components/WordCard/index.js
@@ -27,8 +27,10 @@ const makeStyles = (props) => {
     },
     word: {
       width: 'max-content',
-      flexGrow: 2
-    }
+      flexGrow: 2,
+      textOverflow: 'ellipsis',
+      overflow: 'hidden',
+    },
   };
 
   if (isSuggestion) {
@@ -114,7 +116,7 @@ class WordCard extends React.Component {
     return (
       <div style={{flex: 1}}>
         <div style={styles.root}>
-        <span style={{flex: 1, display: 'flex'}}>
+        <span style={{flex: 1, display: 'flex', overflow: 'hidden'}}>
           <span onClick={this._handleClick} style={styles.word}>
             {word}
           </span>

--- a/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
+++ b/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
@@ -269,6 +269,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               Object {
                                 "display": "flex",
                                 "flex": 1,
+                                "overflow": "hidden",
                               }
                             }
                           >
@@ -277,6 +278,8 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               style={
                                 Object {
                                   "flexGrow": 2,
+                                  "overflow": "hidden",
+                                  "textOverflow": "ellipsis",
                                   "width": "max-content",
                                 }
                               }
@@ -387,6 +390,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               Object {
                                 "display": "flex",
                                 "flex": 1,
+                                "overflow": "hidden",
                               }
                             }
                           >
@@ -395,6 +399,8 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               style={
                                 Object {
                                   "flexGrow": 2,
+                                  "overflow": "hidden",
+                                  "textOverflow": "ellipsis",
                                   "width": "max-content",
                                 }
                               }
@@ -517,6 +523,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               Object {
                                 "display": "flex",
                                 "flex": 1,
+                                "overflow": "hidden",
                               }
                             }
                           >
@@ -525,6 +532,8 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               style={
                                 Object {
                                   "flexGrow": 2,
+                                  "overflow": "hidden",
+                                  "textOverflow": "ellipsis",
                                   "width": "max-content",
                                 }
                               }
@@ -648,6 +657,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               Object {
                                 "display": "flex",
                                 "flex": 1,
+                                "overflow": "hidden",
                               }
                             }
                           >
@@ -656,6 +666,8 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               style={
                                 Object {
                                   "flexGrow": 2,
+                                  "overflow": "hidden",
+                                  "textOverflow": "ellipsis",
                                   "width": "max-content",
                                 }
                               }
@@ -974,6 +986,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               Object {
                                 "display": "flex",
                                 "flex": 1,
+                                "overflow": "hidden",
                               }
                             }
                           >
@@ -982,6 +995,8 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               style={
                                 Object {
                                   "flexGrow": 2,
+                                  "overflow": "hidden",
+                                  "textOverflow": "ellipsis",
                                   "width": "max-content",
                                 }
                               }
@@ -1092,6 +1107,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               Object {
                                 "display": "flex",
                                 "flex": 1,
+                                "overflow": "hidden",
                               }
                             }
                           >
@@ -1100,6 +1116,8 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               style={
                                 Object {
                                   "flexGrow": 2,
+                                  "overflow": "hidden",
+                                  "textOverflow": "ellipsis",
                                   "width": "max-content",
                                 }
                               }
@@ -1222,6 +1240,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               Object {
                                 "display": "flex",
                                 "flex": 1,
+                                "overflow": "hidden",
                               }
                             }
                           >
@@ -1230,6 +1249,8 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               style={
                                 Object {
                                   "flexGrow": 2,
+                                  "overflow": "hidden",
+                                  "textOverflow": "ellipsis",
                                   "width": "max-content",
                                 }
                               }
@@ -1353,6 +1374,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               Object {
                                 "display": "flex",
                                 "flex": 1,
+                                "overflow": "hidden",
                               }
                             }
                           >
@@ -1361,6 +1383,8 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               style={
                                 Object {
                                   "flexGrow": 2,
+                                  "overflow": "hidden",
+                                  "textOverflow": "ellipsis",
                                   "width": "max-content",
                                 }
                               }

--- a/src/components/WordList/__tests__/__snapshots__/WordList.test.js.snap
+++ b/src/components/WordList/__tests__/__snapshots__/WordList.test.js.snap
@@ -45,6 +45,7 @@ Array [
               Object {
                 "display": "flex",
                 "flex": 1,
+                "overflow": "hidden",
               }
             }
           >
@@ -53,6 +54,8 @@ Array [
               style={
                 Object {
                   "flexGrow": 2,
+                  "overflow": "hidden",
+                  "textOverflow": "ellipsis",
                   "width": "max-content",
                 }
               }
@@ -105,6 +108,7 @@ Array [
               Object {
                 "display": "flex",
                 "flex": 1,
+                "overflow": "hidden",
               }
             }
           >
@@ -113,6 +117,8 @@ Array [
               style={
                 Object {
                   "flexGrow": 2,
+                  "overflow": "hidden",
+                  "textOverflow": "ellipsis",
                   "width": "max-content",
                 }
               }
@@ -166,6 +172,7 @@ Array [
               Object {
                 "display": "flex",
                 "flex": 1,
+                "overflow": "hidden",
               }
             }
           >
@@ -174,6 +181,8 @@ Array [
               style={
                 Object {
                   "flexGrow": 2,
+                  "overflow": "hidden",
+                  "textOverflow": "ellipsis",
                   "width": "max-content",
                 }
               }

--- a/src/components/__tests__/__snapshots__/AlignmentGrid.test.js.snap
+++ b/src/components/__tests__/__snapshots__/AlignmentGrid.test.js.snap
@@ -101,6 +101,7 @@ exports[`AlignmentGrid renders Luke 1:1 1`] = `
                         Object {
                           "display": "flex",
                           "flex": 1,
+                          "overflow": "hidden",
                         }
                       }
                     >
@@ -109,6 +110,8 @@ exports[`AlignmentGrid renders Luke 1:1 1`] = `
                         style={
                           Object {
                             "flexGrow": 2,
+                            "overflow": "hidden",
+                            "textOverflow": "ellipsis",
                             "width": "max-content",
                           }
                         }
@@ -245,6 +248,7 @@ exports[`AlignmentGrid renders Luke 1:1 1`] = `
                         Object {
                           "display": "flex",
                           "flex": 1,
+                          "overflow": "hidden",
                         }
                       }
                     >
@@ -253,6 +257,8 @@ exports[`AlignmentGrid renders Luke 1:1 1`] = `
                         style={
                           Object {
                             "flexGrow": 2,
+                            "overflow": "hidden",
+                            "textOverflow": "ellipsis",
                             "width": "max-content",
                           }
                         }
@@ -389,6 +395,7 @@ exports[`AlignmentGrid renders Luke 1:1 1`] = `
                         Object {
                           "display": "flex",
                           "flex": 1,
+                          "overflow": "hidden",
                         }
                       }
                     >
@@ -397,6 +404,8 @@ exports[`AlignmentGrid renders Luke 1:1 1`] = `
                         style={
                           Object {
                             "flexGrow": 2,
+                            "overflow": "hidden",
+                            "textOverflow": "ellipsis",
                             "width": "max-content",
                           }
                         }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- changed wordbank width to be variable from 100 to 400px (previously was fixed at 160px).
- changed word cards so oversized text will show ellipsis instead of overflowing card

#### Please include detailed Test instructions for your pull request:
- can use test build attached below.
- for testing can use this project with long greek words: https://git.door43.org/Door43-Catalog/el-x-koine_ugnt/raw/branch/master/57-TIT.usfm
- open project in WA
- switch between verses and should see wordbank width expand to match size of the longest word.  
- edit a verse to make a word very-very long.  Word bank should stop a 400px and word should not overflow word card - instead should see it truncated with ellipsis.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)
