### PR TITLE
Bugfix 5640/Do not invalidate empty verse

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -304,7 +304,7 @@ export default class Api extends ToolApi {
     } = props;
     const {store} = this.context;
 
-    if (!(verse in targetBook[chapter] && verse in sourceBook[chapter])) {
+    if (!(verse in targetBook[chapter] && targetBook[chapter][verse] && verse in sourceBook[chapter])) {
       console.warn(`Could not validate missing verse ${chapter}:${verse}`);
       return true;
     }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix for empty verse - don't invalidate.

#### Please include detailed Test instructions for your pull request:
- test with attached build below
- do local import this project: [en_act.T.usfm.zip](https://github.com/unfoldingWord-dev/translationCore/files/2721619/en_act.T.usfm.zip).  Will see warning the 19:41 is missing.
- launch WA - will see invalidation warning.
- toggle group menu filter for invalidated.  Should only see acts 3:1,  acts 19:41 should not be toggled invalidated since it is an empty verse.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)
