### PR TITLE
fix wordbank resizing when words are dragged

### DIFF
--- a/src/components/AlignmentCard/__tests__/__snapshots__/AlignmentCard.test.js.snap
+++ b/src/components/AlignmentCard/__tests__/__snapshots__/AlignmentCard.test.js.snap
@@ -109,6 +109,7 @@ exports[`has a bottom word 1`] = `
                     "overflow": "hidden",
                     "textOverflow": "ellipsis",
                     "width": "max-content",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -217,6 +218,7 @@ exports[`has a top and bottom word 1`] = `
                     "overflow": "hidden",
                     "textOverflow": "ellipsis",
                     "width": "max-content",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -289,6 +291,7 @@ exports[`has a top and bottom word 1`] = `
                     "overflow": "hidden",
                     "textOverflow": "ellipsis",
                     "width": "max-content",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -397,6 +400,7 @@ exports[`has a top word 1`] = `
                     "overflow": "hidden",
                     "textOverflow": "ellipsis",
                     "width": "max-content",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -546,6 +550,7 @@ exports[`has multiple bottom words 1`] = `
                     "overflow": "hidden",
                     "textOverflow": "ellipsis",
                     "width": "max-content",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -591,6 +596,7 @@ exports[`has multiple bottom words 1`] = `
                     "overflow": "hidden",
                     "textOverflow": "ellipsis",
                     "width": "max-content",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -699,6 +705,7 @@ exports[`has multiple top and bottom words 1`] = `
                     "overflow": "hidden",
                     "textOverflow": "ellipsis",
                     "width": "max-content",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -744,6 +751,7 @@ exports[`has multiple top and bottom words 1`] = `
                     "overflow": "hidden",
                     "textOverflow": "ellipsis",
                     "width": "max-content",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -816,6 +824,7 @@ exports[`has multiple top and bottom words 1`] = `
                     "overflow": "hidden",
                     "textOverflow": "ellipsis",
                     "width": "max-content",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -861,6 +870,7 @@ exports[`has multiple top and bottom words 1`] = `
                     "overflow": "hidden",
                     "textOverflow": "ellipsis",
                     "width": "max-content",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -969,6 +979,7 @@ exports[`has multiple top words 1`] = `
                     "overflow": "hidden",
                     "textOverflow": "ellipsis",
                     "width": "max-content",
+                    "wordBreak": "break-all",
                   }
                 }
               >
@@ -1014,6 +1025,7 @@ exports[`has multiple top words 1`] = `
                     "overflow": "hidden",
                     "textOverflow": "ellipsis",
                     "width": "max-content",
+                    "wordBreak": "break-all",
                   }
                 }
               >

--- a/src/components/WordCard/__tests__/__snapshots__/WordCard.test.js.snap
+++ b/src/components/WordCard/__tests__/__snapshots__/WordCard.test.js.snap
@@ -38,6 +38,7 @@ exports[`is a suggestion 1`] = `
             "overflow": "hidden",
             "textOverflow": "ellipsis",
             "width": "max-content",
+            "wordBreak": "break-all",
           }
         }
       >
@@ -124,6 +125,7 @@ exports[`occurs multiple times 1`] = `
             "overflow": "hidden",
             "textOverflow": "ellipsis",
             "width": "max-content",
+            "wordBreak": "break-all",
           }
         }
       >
@@ -183,6 +185,7 @@ exports[`occurs once 1`] = `
             "overflow": "hidden",
             "textOverflow": "ellipsis",
             "width": "max-content",
+            "wordBreak": "break-all",
           }
         }
       >
@@ -231,6 +234,7 @@ exports[`renders rtl 1`] = `
             "overflow": "hidden",
             "textOverflow": "ellipsis",
             "width": "max-content",
+            "wordBreak": "break-all",
           }
         }
       >

--- a/src/components/WordCard/index.js
+++ b/src/components/WordCard/index.js
@@ -30,6 +30,7 @@ const makeStyles = (props) => {
       flexGrow: 2,
       textOverflow: 'ellipsis',
       overflow: 'hidden',
+      wordBreak: 'break-all'
     },
   };
 

--- a/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
+++ b/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
@@ -139,7 +139,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
               "height": "100%",
               "overflowY": "auto",
               "padding": "5px 8px 5px 5px",
-              "width": "100%",
+              "width": "150px",
             }
           }
         >
@@ -281,6 +281,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                   "overflow": "hidden",
                                   "textOverflow": "ellipsis",
                                   "width": "max-content",
+                                  "wordBreak": "break-all",
                                 }
                               }
                             >
@@ -402,6 +403,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                   "overflow": "hidden",
                                   "textOverflow": "ellipsis",
                                   "width": "max-content",
+                                  "wordBreak": "break-all",
                                 }
                               }
                             >
@@ -535,6 +537,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                   "overflow": "hidden",
                                   "textOverflow": "ellipsis",
                                   "width": "max-content",
+                                  "wordBreak": "break-all",
                                 }
                               }
                             >
@@ -669,6 +672,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                   "overflow": "hidden",
                                   "textOverflow": "ellipsis",
                                   "width": "max-content",
+                                  "wordBreak": "break-all",
                                 }
                               }
                             >
@@ -856,7 +860,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
               "height": "100%",
               "overflowY": "auto",
               "padding": "5px 8px 5px 5px",
-              "width": "100%",
+              "width": "150px",
             }
           }
         >
@@ -998,6 +1002,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                   "overflow": "hidden",
                                   "textOverflow": "ellipsis",
                                   "width": "max-content",
+                                  "wordBreak": "break-all",
                                 }
                               }
                             >
@@ -1119,6 +1124,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                   "overflow": "hidden",
                                   "textOverflow": "ellipsis",
                                   "width": "max-content",
+                                  "wordBreak": "break-all",
                                 }
                               }
                             >
@@ -1252,6 +1258,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                   "overflow": "hidden",
                                   "textOverflow": "ellipsis",
                                   "width": "max-content",
+                                  "wordBreak": "break-all",
                                 }
                               }
                             >
@@ -1386,6 +1393,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                   "overflow": "hidden",
                                   "textOverflow": "ellipsis",
                                   "width": "max-content",
+                                  "wordBreak": "break-all",
                                 }
                               }
                             >

--- a/src/components/WordList/__tests__/__snapshots__/WordList.test.js.snap
+++ b/src/components/WordList/__tests__/__snapshots__/WordList.test.js.snap
@@ -57,6 +57,7 @@ Array [
                   "overflow": "hidden",
                   "textOverflow": "ellipsis",
                   "width": "max-content",
+                  "wordBreak": "break-all",
                 }
               }
             >
@@ -120,6 +121,7 @@ Array [
                   "overflow": "hidden",
                   "textOverflow": "ellipsis",
                   "width": "max-content",
+                  "wordBreak": "break-all",
                 }
               }
             >
@@ -184,6 +186,7 @@ Array [
                   "overflow": "hidden",
                   "textOverflow": "ellipsis",
                   "width": "max-content",
+                  "wordBreak": "break-all",
                 }
               }
             >

--- a/src/components/WordList/index.js
+++ b/src/components/WordList/index.js
@@ -114,7 +114,7 @@ class DroppableWordList extends React.Component {
         id='wordList'
         style={{
           height: '100%',
-          width: '100%',
+          width: '150px',
           backgroundColor: '#DCDCDC',
           overflowY: 'auto',
           padding: '5px 8px 5px 5px',

--- a/src/components/__tests__/__snapshots__/AlignmentGrid.test.js.snap
+++ b/src/components/__tests__/__snapshots__/AlignmentGrid.test.js.snap
@@ -113,6 +113,7 @@ exports[`AlignmentGrid renders Luke 1:1 1`] = `
                             "overflow": "hidden",
                             "textOverflow": "ellipsis",
                             "width": "max-content",
+                            "wordBreak": "break-all",
                           }
                         }
                       >
@@ -260,6 +261,7 @@ exports[`AlignmentGrid renders Luke 1:1 1`] = `
                             "overflow": "hidden",
                             "textOverflow": "ellipsis",
                             "width": "max-content",
+                            "wordBreak": "break-all",
                           }
                         }
                       >
@@ -407,6 +409,7 @@ exports[`AlignmentGrid renders Luke 1:1 1`] = `
                             "overflow": "hidden",
                             "textOverflow": "ellipsis",
                             "width": "max-content",
+                            "wordBreak": "break-all",
                           }
                         }
                       >


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Corrects a bug where dragging words would cause the wordbank to resize. See https://github.com/unfoldingWord/translationCore/issues/6633
- Adds support for very long words in the wordbank. Long words now break and wrap. See https://github.com/unfoldingword/translationcore/issues/6627

#### Please include detailed Test instructions for your pull request:
- Open a project in the wordAlignment tool and drag a word. The wordbank should maintain it's width.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)
