### PR TITLE
Bugfix 6675/fix verse edit in tools

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -167,7 +167,11 @@ export default class Api extends ToolApi {
     const toolAPI = tools && tools[toolName];
 
     if (toolAPI) {
-      return toolAPI.trigger('validateVerse', chapter, verse, silent);
+      try {
+        return toolAPI.trigger('validateVerse', chapter, verse, silent);
+      } catch (e) {
+        console.error(`validateVerseInTool(${toolName}) - validateVerse failed`, e);
+      }
     }
     return false;
   }

--- a/src/Api.js
+++ b/src/Api.js
@@ -47,6 +47,7 @@ import {
   INVALID_KEY,
   UNALIGNED_KEY,
 } from './state/reducers/GroupMenu';
+import {TRANSLATION_NOTES, TRANSLATION_WORDS} from "./common/constants";
 const GLOBAL_ALIGNMENT_MEM_CACHE_TYPE = SESSION_STORAGE;
 
 export default class Api extends ToolApi {
@@ -57,6 +58,7 @@ export default class Api extends ToolApi {
     this._validateBook = this._validateBook.bind(this);
     this.validateBook = this.validateBook.bind(this);
     this.validateVerse = this.validateVerse.bind(this);
+    this.validateVerseSelections = this.validateVerseSelections.bind(this);
     this._loadBookAlignments = this._loadBookAlignments.bind(this);
     this._showResetDialog = this._showResetDialog.bind(this);
     this.getProgress = this.getProgress.bind(this);
@@ -136,6 +138,38 @@ export default class Api extends ToolApi {
         resetVerse(chapter, verse, sourceTokens, targetTokens);
       }
     }
+  }
+
+  /**
+   * method to validate verse selections
+   * @param {number} chapter
+   * @param {number} verse
+   * @param {boolean} silent - if true, alignments invalidated prompt is not displayed, only valid returned
+   * @return {boolean} returns true if no checks invalidated
+   */
+  validateVerseSelections(chapter, verse, silent=false) {
+    const tnValid = this.validateVerseInTool(TRANSLATION_NOTES, chapter, verse, silent);
+    const twValid = this.validateVerseInTool(TRANSLATION_WORDS, chapter, verse, silent);
+    return tnValid && twValid;
+  }
+
+  /**
+   * will call validateVerse in the tool API
+   * @param {string} toolName
+   * @param {number} chapter
+   * @param {number} verse
+   * @param {boolean} silent - if true, alignments invalidated prompt is not displayed, only valid returned
+   * @return {boolean} returns true if no checks invalidated
+   */
+  validateVerseInTool(toolName, chapter, verse, silent) {
+    const {tc: {tools}} = this.props;
+
+    const toolAPI = tools && tools[toolName];
+
+    if (toolAPI) {
+      return toolAPI.trigger('validateVerse', chapter, verse, silent);
+    }
+    return false;
   }
 
   /**

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -32,4 +32,4 @@ export const ALERT_ALIGNMENTS_RESET_ID = 'alignments_reset';
 export const ALERT_SELECTIONS_INVALIDATED_ID = 'selections_invalidated_id';
 export const ALERT_ALIGNMENTS_AND_SELECTIONS_RESET_MSG = 'invalid_verse_alignments_and_selections';
 export const ALERT_SELECTIONS_INVALIDATED_MSG = 'selections_invalidated';
-export const ALERT_ALIGNMENTS_RESET_MSG = 'alignments_reset_wa_tool';
+export const ALERT_ALIGNMENTS_RESET_MSG = 'alignments_reset';

--- a/src/state/actions/verseEditActions.js
+++ b/src/state/actions/verseEditActions.js
@@ -137,8 +137,7 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
   if (showSelectionInvalidated || showAlignmentsInvalidated) {
     dispatch(showInvalidatedWarnings(showSelectionInvalidated, showAlignmentsInvalidated, translate, showIgnorableAlert));
   }
-  dispatch(doBackgroundVerseEditsUpdates(verseEdit, contextIdWithVerseEdit,
-    currentCheckContextId, actionsBatch, currentToolName));
+  dispatch(doBackgroundVerseEditsUpdates(verseEdit, contextIdWithVerseEdit, currentCheckContextId, actionsBatch));
 };
 
 /**
@@ -160,9 +159,8 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
  * @param {Object} contextIdWithVerseEdit - contextId of verse being edited
  * @param {Object} currentCheckContextId - contextId of group menu item selected
  * @param {array} batchGroupData - if present then add group data actions to this array for later batch operation
- * @param {string} toolName - tool Name.
  */
-export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit, currentCheckContextId, batchGroupData = null, toolName) => (dispatch) => {
+export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit, currentCheckContextId, batchGroupData = null) => (dispatch) => {
   const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
   const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
 

--- a/src/state/actions/verseEditActions.js
+++ b/src/state/actions/verseEditActions.js
@@ -1,10 +1,6 @@
 import { batchActions } from 'redux-batched-actions';
 import generateTimestamp from '../../utils/generateTimestamp';
 import { getContextId, getGroupsData } from '../../state/selectors';
-import {
-  TRANSLATION_WORDS,
-  TRANSLATION_NOTES,
-} from '../../common/constants';
 import { writeTranslationWordsVerseEditToFile } from '../../utils/verseEditHelpers';
 import { getGroupDataForVerse } from '../../utils/groupDataHelpers';
 import { saveVerseEdit } from '../../utils/localStorage';
@@ -14,7 +10,7 @@ import {
   TOGGLE_VERSE_EDITS_IN_GROUPDATA,
   TOGGLE_MULTIPLE_VERSE_EDITS_IN_GROUPDATA,
 } from './actionTypes';
-import { validateSelections, showInvalidatedWarnings } from './selectionsActions';
+import { showInvalidatedWarnings } from './selectionsActions';
 
 /**
  * This is called by tool when a verse has been edited. It updates group data reducer for current tool
@@ -142,7 +138,7 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
     dispatch(showInvalidatedWarnings(showSelectionInvalidated, showAlignmentsInvalidated, translate, showIgnorableAlert));
   }
   dispatch(doBackgroundVerseEditsUpdates(verseEdit, contextIdWithVerseEdit,
-    currentCheckContextId, actionsBatch, currentToolName, projectSaveLocation));
+    currentCheckContextId, actionsBatch, currentToolName));
 };
 
 /**
@@ -165,9 +161,8 @@ export const updateVerseEditStatesAndCheckAlignments = (verseEdit, contextIdWith
  * @param {Object} currentCheckContextId - contextId of group menu item selected
  * @param {array} batchGroupData - if present then add group data actions to this array for later batch operation
  * @param {string} toolName - tool Name.
- * @param {string} projectSaveLocation - project Directory path.
  */
-export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit, currentCheckContextId, batchGroupData = null, toolName, projectSaveLocation) => (dispatch, getState) => {
+export const doBackgroundVerseEditsUpdates = (verseEdit, contextIdWithVerseEdit, currentCheckContextId, batchGroupData = null, toolName) => (dispatch) => {
   const chapterWithVerseEdit = contextIdWithVerseEdit.reference.chapter;
   const verseWithVerseEdit = contextIdWithVerseEdit.reference.verse;
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- change updateVerseEditStatesAndCheckAlignments() to call validateVerse in tW and tN through API to validate selections so tW and tN can do the validation and then update the group data with latest verse edits.

#### Please include detailed Test instructions for your pull request:
- can test using tCore and WA branches `bugfix-mcleanb-6675.2`
- in tN or tW: using scripture pane, edit different verse than current verse and it should mark all checks in the edited verse as edited
- in WA edit a verse and should see verse edit indications in tW and tN.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/wordalignment/253)
<!-- Reviewable:end -->
