### PR TITLE
Hide tooltip when dragging target words

### DIFF
--- a/src/components/SecondaryToken.js
+++ b/src/components/SecondaryToken.js
@@ -110,6 +110,7 @@ class SecondaryToken extends React.Component {
         onClick={this.handleClick}
       >
         <Word
+          disableTooltip={isDragging}
           selected={selected}
           word={token.text}
           disabled={disabled}
@@ -193,6 +194,10 @@ const dragHandler = {
     if (monitor.didDrop() && dropResult && typeof props.onEndDrag === 'function') {
       props.onEndDrag();
     }
+  },
+  isDragging(props, monitor) {
+    const item = monitor.getItem();
+    return item.token.tokenPos === props.token.tokenPos;
   }
 };
 

--- a/src/components/WordCard/index.js
+++ b/src/components/WordCard/index.js
@@ -143,7 +143,7 @@ class WordCard extends React.Component {
   }
 
   render() {
-    const {word, occurrence, occurrences, isSuggestion} = this.props;
+    const {word, occurrence, occurrences, isSuggestion, disableTooltip} = this.props;
     const styles = makeStyles(this.props);
     const {tooltip} = this.state;
     // TRICKY: the <ReactTooltip/> is in WordList.js
@@ -154,7 +154,7 @@ class WordCard extends React.Component {
             data-type="dark"
             data-for="word-overflow-tooltip"
             data-multiline={true}
-            data-tip-disable={!tooltip}
+            data-tip-disable={!tooltip || disableTooltip}
             data-delay-show={200}
             data-delay-hide={100}>
         <div style={{flex: 1}} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
@@ -178,6 +178,7 @@ class WordCard extends React.Component {
 }
 
 WordCard.propTypes = {
+  disableTooltip: PropTypes.bool,
   selected: PropTypes.bool,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
@@ -197,7 +198,8 @@ WordCard.defaultProps = {
   disabled: false,
   isSuggestion: false,
   selected: false,
-  direction: 'ltr'
+  direction: 'ltr',
+  disableTooltip: false
 };
 
 export default WordCard;

--- a/src/components/WordList/WordList.js
+++ b/src/components/WordList/WordList.js
@@ -93,7 +93,7 @@ class WordList extends React.Component {
             return (
               <div
                 key={index}
-                style={{padding: '10px'}}>
+                style={{padding: '5px 10px'}}>
                 <SecondaryToken
                   direction={direction}
                   onEndDrag={onWordDragged}

--- a/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
+++ b/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
@@ -188,7 +188,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 key="0"
                 style={
                   Object {
-                    "padding": "10px",
+                    "padding": "5px 10px",
                   }
                 }
               >
@@ -237,6 +237,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     >
                       <WordCard
                         direction="ltr"
+                        disableTooltip={false}
                         disabled={false}
                         isSuggestion={false}
                         occurrence={1}
@@ -323,7 +324,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 key="1"
                 style={
                   Object {
-                    "padding": "10px",
+                    "padding": "5px 10px",
                   }
                 }
               >
@@ -372,6 +373,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     >
                       <WordCard
                         direction="ltr"
+                        disableTooltip={false}
                         disabled={false}
                         isSuggestion={false}
                         occurrence={1}
@@ -470,7 +472,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 key="2"
                 style={
                   Object {
-                    "padding": "10px",
+                    "padding": "5px 10px",
                   }
                 }
               >
@@ -519,6 +521,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     >
                       <WordCard
                         direction="ltr"
+                        disableTooltip={false}
                         disabled={false}
                         isSuggestion={false}
                         occurrence={2}
@@ -617,7 +620,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 key="3"
                 style={
                   Object {
-                    "padding": "10px",
+                    "padding": "5px 10px",
                   }
                 }
               >
@@ -666,6 +669,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     >
                       <WordCard
                         direction="ltr"
+                        disableTooltip={false}
                         disabled={true}
                         isSuggestion={false}
                         occurrence={1}
@@ -981,7 +985,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 key="0"
                 style={
                   Object {
-                    "padding": "10px",
+                    "padding": "5px 10px",
                   }
                 }
               >
@@ -1030,6 +1034,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     >
                       <WordCard
                         direction="ltr"
+                        disableTooltip={false}
                         disabled={false}
                         isSuggestion={false}
                         occurrence={1}
@@ -1116,7 +1121,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 key="1"
                 style={
                   Object {
-                    "padding": "10px",
+                    "padding": "5px 10px",
                   }
                 }
               >
@@ -1165,6 +1170,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     >
                       <WordCard
                         direction="ltr"
+                        disableTooltip={false}
                         disabled={false}
                         isSuggestion={false}
                         occurrence={1}
@@ -1263,7 +1269,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 key="2"
                 style={
                   Object {
-                    "padding": "10px",
+                    "padding": "5px 10px",
                   }
                 }
               >
@@ -1312,6 +1318,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     >
                       <WordCard
                         direction="ltr"
+                        disableTooltip={false}
                         disabled={false}
                         isSuggestion={false}
                         occurrence={2}
@@ -1410,7 +1417,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 key="3"
                 style={
                   Object {
-                    "padding": "10px",
+                    "padding": "5px 10px",
                   }
                 }
               >
@@ -1459,6 +1466,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     >
                       <WordCard
                         direction="ltr"
+                        disableTooltip={false}
                         disabled={true}
                         isSuggestion={false}
                         occurrence={1}

--- a/src/components/WordList/__tests__/__snapshots__/WordList.test.js.snap
+++ b/src/components/WordList/__tests__/__snapshots__/WordList.test.js.snap
@@ -27,7 +27,7 @@ exports[`snapshot has words 1`] = `
   <div
     style={
       Object {
-        "padding": "10px",
+        "padding": "5px 10px",
       }
     }
   >
@@ -104,7 +104,7 @@ exports[`snapshot has words 1`] = `
   <div
     style={
       Object {
-        "padding": "10px",
+        "padding": "5px 10px",
       }
     }
   >
@@ -181,7 +181,7 @@ exports[`snapshot has words 1`] = `
   <div
     style={
       Object {
-        "padding": "10px",
+        "padding": "5px 10px",
       }
     }
   >


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Related to https://github.com/unfoldingWord/translationCore/issues/6627
- Decreases padding between words in the wordbank.
- Disables tooltips when a word is being dragged.

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/wordalignment/254)
<!-- Reviewable:end -->
