### PR TITLE
disabled verbose warnings from wordmap

### DIFF
--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -108,7 +108,7 @@ export const generateMAP = (
   targetBook, state, currentChapter, currentVerse) => new Promise(resolve => {
   setTimeout(() => {
     // TODO: determine the maximum require target ngram length from the alignment memory before creating the map
-    const map = new WordMap({ targetNgramLength: 5, nGramWarnings: false });
+    const map = new WordMap({ targetNgramLength: 5, warnings: false});
 
     for (const chapter of Object.keys(targetBook)) {
       const chapterAlignments = getChapterAlignments(state, chapter);


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Related to https://github.com/unfoldingword/translationcore/issues/6237.... but not really
- This corrects a parameter to wordmap to disable verbose logging. This makes it a bit easier to read the console logs.

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/wordalignment/259)
<!-- Reviewable:end -->
