### PR TITLE
Bugfix 6790/Fix to clear contextId when Project is changed

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -31,7 +31,6 @@ import {
 } from './utils/CheckDataHelper';
 import {
   alignTargetToken,
-  clearContextId,
   clearState,
   indexChapterAlignments,
   moveSourceToken,
@@ -40,6 +39,9 @@ import {
   resetVerse,
   unalignTargetToken,
 } from './state/actions';
+import {
+  clearContextId,
+} from './state/actions/contextIdActions';
 import SimpleCache, { SESSION_STORAGE } from './utils/SimpleCache';
 import { migrateChapterAlignments } from './utils/migrations';
 // consts

--- a/src/Api.js
+++ b/src/Api.js
@@ -31,6 +31,7 @@ import {
 } from './utils/CheckDataHelper';
 import {
   alignTargetToken,
+  clearContextId,
   clearState,
   indexChapterAlignments,
   moveSourceToken,
@@ -489,9 +490,10 @@ export default class Api extends ToolApi {
    * Lifecycle method
    */
   toolWillConnect() {
-    const { clearState } = this.props;
+    const { clearState, clearContextId } = this.props;
     this._clearCachedAlignmentMemory();
     clearState();
+    clearContextId();
     this._clearGroupMenuReducer();
     this._loadBookAlignments(this.props);
   }
@@ -592,6 +594,7 @@ export default class Api extends ToolApi {
     const methods = {
       alignTargetToken,
       clearGroupMenu,
+      clearContextId,
       clearState,
       indexChapterAlignments,
       loadGroupMenuItem,


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- clear contextId when Project is changed

#### Please include detailed Test instructions for your pull request:
- this will fix scenarios 3 & 4 from https://github.com/unfoldingWord/translationCore/issues/6790. Crashes due to changing projects when contextId of old project is outside range of new project.
- scenario 1 & 2 will be fixed by Joel's tc-ui-toolkit PR.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/wordalignment/265)
<!-- Reviewable:end -->
