### PR TITLE
Bugfix 6790/Fix to clear out all group data reducers

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -25,6 +25,8 @@ import {
   setGroupMenuItemFinished,
   setGroupMenuItemInvalid,
 } from './state/actions/GroupMenuActions';
+import { clearGroupsIndex } from './state/actions/groupsIndexActions';
+import { clearGroupsData } from './state/actions/groupsDataActions';
 import {
   getIsVerseFinished,
   getIsVerseEdited,
@@ -66,7 +68,7 @@ export default class Api extends ToolApi {
     this._showResetDialog = this._showResetDialog.bind(this);
     this.getProgress = this.getProgress.bind(this);
     this._clearCachedAlignmentMemory = this._clearCachedAlignmentMemory.bind(this);
-    this._clearGroupMenuReducer = this._clearGroupMenuReducer.bind(this);
+    this._clearReducers = this._clearReducers.bind(this);
     this.getVerseRawText = this.getVerseRawText.bind(this);
     this.getVerseData = this.getVerseData.bind(this);
   }
@@ -481,22 +483,29 @@ export default class Api extends ToolApi {
   }
 
   /**
-   * resets cached data in group menu reducer
+   * resets cached data in key reducers
    */
-  _clearGroupMenuReducer() {
-    const { clearGroupMenu } = this.props;
+  _clearReducers() {
+    const {
+      clearState,
+      clearContextId,
+      clearGroupMenu,
+      clearGroupsData,
+      clearGroupsIndex,
+    } = this.props;
+    clearState();
+    clearContextId();
     clearGroupMenu();
+    clearGroupsData();
+    clearGroupsIndex();
   }
 
   /**
    * Lifecycle method
    */
   toolWillConnect() {
-    const { clearState, clearContextId } = this.props;
     this._clearCachedAlignmentMemory();
-    clearState();
-    clearContextId();
-    this._clearGroupMenuReducer();
+    this._clearReducers();
     this._loadBookAlignments(this.props);
   }
 
@@ -595,8 +604,10 @@ export default class Api extends ToolApi {
   mapDispatchToProps(dispatch) {
     const methods = {
       alignTargetToken,
-      clearGroupMenu,
       clearContextId,
+      clearGroupMenu,
+      clearGroupsData,
+      clearGroupsIndex,
       clearState,
       indexChapterAlignments,
       loadGroupMenuItem,


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Fix to clear out all group data reducers when tool is connected to project

#### Please include detailed Test instructions for your pull request:
- test with tC develop branch.  SHould fix the fail at bottom of issue

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/wordalignment/266)
<!-- Reviewable:end -->
