### PR TITLE
fixed broken tooltips in the wordbank

### DIFF
--- a/src/components/WordCard/index.js
+++ b/src/components/WordCard/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import WordOccurrence from './WordOccurrence';
 import Controls from './Controls';
+import ReactTooltip from 'react-tooltip';
 
 /**
  * Generates the component styles
@@ -152,39 +153,42 @@ class WordCard extends React.Component {
     const { tooltip } = this.state;
     // TRICKY: the <ReactTooltip/> is in WordList.js
     return (
-      <span
-        data-tip={word}
-        data-place="bottom"
-        data-effect="solid"
-        data-type="dark"
-        data-for="word-overflow-tooltip"
-        data-multiline={true}
-        data-tip-disable={!tooltip || disableTooltip}
-        data-delay-show={200}
-        data-delay-hide={100}>
-        <div style={{ flex: 1 }} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
-          <div style={styles.root}>
-            <span style={{
-              flex: 1, display: 'flex', overflow: 'hidden',
-            }}>
-              <span
-                ref={this.wordRef}
-                style={styles.word}
-                className={targetLanguageFontClassName}
-                onClick={this._handleClick}
-              >
-                {word}
-              </span>
-              {isSuggestion ? (
-                <Controls onCancel={this._handleCancelClick}/>
-              ) : null}
+      <React.Fragment>
+        <span
+          data-tip={word}
+          data-place="bottom"
+          data-effect="solid"
+          data-type="dark"
+          data-for="word-overflow-tooltip"
+          data-multiline={true}
+          data-tip-disable={!tooltip || disableTooltip}
+          data-delay-show={400}
+          data-delay-hide={200}>
+          <div style={{ flex: 1 }} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+            <div style={styles.root}>
+              <span style={{
+                flex: 1, display: 'flex', overflow: 'hidden',
+              }}>
+                <span
+                  ref={this.wordRef}
+                  style={styles.word}
+                  className={targetLanguageFontClassName}
+                  onClick={this._handleClick}
+                >
+                  {word}
+                </span>
+                {isSuggestion ? (
+                  <Controls onCancel={this._handleCancelClick}/>
+                ) : null}
 
-            </span>
-            <WordOccurrence occurrence={occurrence}
-              occurrences={occurrences}/>
+              </span>
+              <WordOccurrence occurrence={occurrence}
+                              occurrences={occurrences}/>
+            </div>
           </div>
-        </div>
-      </span>
+        </span>
+        <ReactTooltip id="word-overflow-tooltip" className={targetLanguageFontClassName}/>
+      </React.Fragment>
     );
   }
 }

--- a/src/components/WordList/WordList.js
+++ b/src/components/WordList/WordList.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Token } from 'wordmap-lexer';
-import ReactTooltip from 'react-tooltip';
 import SecondaryToken from '../SecondaryToken';
 import { getFontClassName } from '../../common/fontUtils';
 
@@ -106,7 +105,6 @@ class WordList extends React.Component {
               />
             </div>
           ))}
-          <ReactTooltip id="word-overflow-tooltip" className={targetLanguageFontClassName} />
         </div>
       );
     }


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Related to https://github.com/unfoldingword/translationcore/issues/6957
- Fixes the broken tooltips in the wordbank.

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)
