### PR TITLE
Bugfix 6984/Fix for Hebrew fonts being clipped and too bold

### DIFF
--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -723,7 +723,7 @@ export class Container extends Component {
 
     if (isHebrew) {
       sourceStyle = {
-        fontSize: '175%', paddingTop: '8px', lineHeight: '100%',
+        fontSize: '175%', paddingTop: '2px', paddingBottom: '2px', lineHeight: 'normal', WebkitFontSmoothing: 'antialiased',
       };
     }
 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix for Hebrew fonts being clipped and too bold

#### Please include detailed Test instructions for your pull request:
- test with tC build bugfix-mcleanb-6984
- in OT projects in wA  should not see the clipping of Hebrew in Alignment grid area and text should be less bold:

<img width="910" alt="Screen Shot 2020-06-22 at 12 45 24 PM" src="https://user-images.githubusercontent.com/14238574/85313695-64eb9700-b486-11ea-872f-f4c666a6944a.png">

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/wordalignment/281)
<!-- Reviewable:end -->
