### PR TITLE
Fixes word tooltips when using arabic font

### DIFF
--- a/src/components/SecondaryToken.js
+++ b/src/components/SecondaryToken.js
@@ -147,6 +147,7 @@ class SecondaryToken extends React.Component {
       isDragging,
       connectDragSource,
       targetLanguageFontClassName,
+      fontScale
     } = this.props;
     const opacity = isDragging ? 0.4 : 1;
 
@@ -160,6 +161,7 @@ class SecondaryToken extends React.Component {
         <Word
           word={token.text}
           style={{ opacity }}
+          fontScale={fontScale}
           selected={selected}
           disabled={disabled}
           direction={direction}
@@ -196,6 +198,7 @@ SecondaryToken.propTypes = {
   direction: PropTypes.oneOf(['ltr', 'rtl']),
   disabled: PropTypes.bool,
   targetLanguageFontClassName: PropTypes.string,
+  fontScale: PropTypes.number
 };
 
 SecondaryToken.defaultProps = {
@@ -206,6 +209,7 @@ SecondaryToken.defaultProps = {
   },
   alignmentIndex: undefined,
   disabled: false,
+  fontScale: 100,
   selectedTokens: [],
   direction: 'ltr',
 };

--- a/src/components/ThemedTooltip.js
+++ b/src/components/ThemedTooltip.js
@@ -6,7 +6,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 function arrowGenerator(color) {
   return {
     '&[x-placement*="bottom"] $arrow': {
-      top: 0,
+      top: 8,
       left: 0,
       marginTop: '-0.95em',
       width: '3em',
@@ -68,7 +68,8 @@ const styles = theme => ({
   bootstrapPopper: arrowGenerator(theme.palette.common.black),
   bootstrapTooltip: {
     backgroundColor: theme.palette.common.black,
-    fontSize: 14,
+    fontSize: "inherit",
+    lineHeight: "inherit",
     maxWidth: 375,
     wordBreak: "break-all"
   },
@@ -112,7 +113,7 @@ class ThemedTooltip extends React.Component {
   };
 
   render() {
-    const { message , children, classes, disabled} = this.props;
+    const { message , children, classes, disabled, targetLanguageFontClassName, fontScale} = this.props;
     const { arrowRef } = this.state;
 
     return (
@@ -124,7 +125,11 @@ class ThemedTooltip extends React.Component {
         leaveDelay={200}
         title={
           <React.Fragment>
-            {message}
+            <span style={{fontSize: `${fontScale}%`}}>
+              <span className={targetLanguageFontClassName}>
+                {message}
+              </span>
+            </span>
             <span className={classes.arrow} ref={this.handleArrowRef} />
           </React.Fragment>
         }
@@ -158,10 +163,13 @@ ThemedTooltip.propTypes = {
   message: PropTypes.string.isRequired,
   children: PropTypes.any.isRequired,
   classes: PropTypes.any.isRequired,
-  disabled: PropTypes.bool
+  targetLanguageFontClassName: PropTypes.any,
+  disabled: PropTypes.bool,
+  fontScale: PropTypes.number
 };
 ThemedTooltip.defaultProps = {
-  disabled: false
+  disabled: false,
+  fontScale: 100
 };
 
 export default withStyles(styles)(ThemedTooltip);

--- a/src/components/WordCard/index.js
+++ b/src/components/WordCard/index.js
@@ -68,12 +68,12 @@ const makeStyles = (props) => {
 };
 
 /**
- * Checks if an element has overflowed it's parent
+ * Checks if an element has overflowed it's parent's width
  * @param element
  * @returns {boolean}
  */
 function isOverflown(element) {
-  return element.scrollHeight > element.clientHeight || element.scrollWidth > element.clientWidth;
+  return element.scrollWidth > element.clientWidth;
 }
 
 
@@ -148,12 +148,13 @@ class WordCard extends React.Component {
       isSuggestion,
       disableTooltip,
       targetLanguageFontClassName,
+      fontScale
     } = this.props;
     const styles = makeStyles(this.props);
     const { tooltip } = this.state;
     return (
       <React.Fragment>
-        <ThemedTooltip message={word} disabled={!tooltip || disableTooltip}>
+        <ThemedTooltip message={word} disabled={!tooltip || disableTooltip} fontScale={fontScale} targetLanguageFontClassName={targetLanguageFontClassName}>
           <div style={{ flex: 1 }} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
             <div style={styles.root}>
               <span style={{
@@ -195,6 +196,7 @@ WordCard.propTypes = {
   isSuggestion: PropTypes.bool,
   direction: PropTypes.oneOf(['ltr', 'rtl']),
   targetLanguageFontClassName: PropTypes.string,
+  fontScale: PropTypes.number
 };
 
 WordCard.defaultProps = {
@@ -206,6 +208,7 @@ WordCard.defaultProps = {
   selected: false,
   direction: 'ltr',
   disableTooltip: false,
+  fontScale: 100
 };
 
 export default WordCard;

--- a/src/components/WordList/WordList.js
+++ b/src/components/WordList/WordList.js
@@ -74,6 +74,7 @@ class WordList extends React.Component {
       selectedWords,
       toolsSettings,
       setToolSettings,
+      toolSettings,
       targetLanguageFont,
     } = this.props;
     const { width, height } = this.state;
@@ -118,6 +119,7 @@ class WordList extends React.Component {
                 style={{ padding: '5px 10px' }}>
                 <SecondaryToken
                   token={token}
+                  fontScale={toolSettings.fontSize}
                   onClick={onWordClick}
                   direction={direction}
                   onEndDrag={onWordDragged}
@@ -144,6 +146,7 @@ WordList.propTypes = {
   direction: PropTypes.oneOf(['ltr', 'rtl']),
   toolsSettings: PropTypes.object.isRequired,
   setToolSettings: PropTypes.func.isRequired,
+  toolSettings: PropTypes.object.isRequired,
   selectedWordPositions: PropTypes.arrayOf(PropTypes.number),
   words: PropTypes.arrayOf(PropTypes.instanceOf(Token)).isRequired,
 };

--- a/src/components/WordList/WordList.js
+++ b/src/components/WordList/WordList.js
@@ -151,6 +151,11 @@ WordList.propTypes = {
   words: PropTypes.arrayOf(PropTypes.instanceOf(Token)).isRequired,
 };
 
-WordList.defaultProps = { direction: 'ltr' };
+WordList.defaultProps = {
+  direction: 'ltr',
+  toolSettings: {
+    fontSize: 100
+  }
+};
 
 export default WordList;

--- a/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
+++ b/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
@@ -155,6 +155,11 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
             onWordDragged={[Function]}
             selectedWordPositions={Array []}
             selectedWords={Array []}
+            toolSettings={
+              Object {
+                "fontSize": 100,
+              }
+            }
             toolsSettings={Object {}}
             verse={1}
             words={
@@ -336,6 +341,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 <DragSource(SecondaryToken)
                   direction="ltr"
                   disabled={false}
+                  fontScale={100}
                   onClick={[Function]}
                   onEndDrag={[Function]}
                   selected={false}
@@ -354,6 +360,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     connectDragSource={[Function]}
                     direction="ltr"
                     disabled={false}
+                    fontScale={100}
                     isDragging={false}
                     isSelected={false}
                     onAccept={[Function]}
@@ -382,6 +389,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                         direction="ltr"
                         disableTooltip={false}
                         disabled={false}
+                        fontScale={100}
                         isSuggestion={false}
                         occurrence={1}
                         occurrences={1}
@@ -397,7 +405,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                       >
                         <WithStyles(ThemedTooltip)
                           disabled={true}
+                          fontScale={100}
                           message="w1"
+                          targetLanguageFontClassName=""
                         >
                           <ThemedTooltip
                             classes={
@@ -412,7 +422,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               }
                             }
                             disabled={true}
+                            fontScale={100}
                             message="w1"
+                            targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
                               PopperProps={
@@ -444,7 +456,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               leaveDelay={200}
                               title={
                                 <UNDEFINED>
-                                  w1
+                                  <span
+                                    style={
+                                      Object {
+                                        "fontSize": "100%",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className=""
+                                    >
+                                      w1
+                                    </span>
+                                  </span>
                                   <span
                                     className="ThemedTooltip-arrow-1"
                                   />
@@ -486,7 +510,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                 leaveDelay={200}
                                 title={
                                   <UNDEFINED>
-                                    w1
+                                    <span
+                                      style={
+                                        Object {
+                                          "fontSize": "100%",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className=""
+                                      >
+                                        w1
+                                      </span>
+                                    </span>
                                     <span
                                       className="ThemedTooltip-arrow-1"
                                     />
@@ -607,6 +643,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 <DragSource(SecondaryToken)
                   direction="ltr"
                   disabled={false}
+                  fontScale={100}
                   onClick={[Function]}
                   onEndDrag={[Function]}
                   selected={false}
@@ -625,6 +662,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     connectDragSource={[Function]}
                     direction="ltr"
                     disabled={false}
+                    fontScale={100}
                     isDragging={false}
                     isSelected={false}
                     onAccept={[Function]}
@@ -653,6 +691,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                         direction="ltr"
                         disableTooltip={false}
                         disabled={false}
+                        fontScale={100}
                         isSuggestion={false}
                         occurrence={1}
                         occurrences={2}
@@ -668,7 +707,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                       >
                         <WithStyles(ThemedTooltip)
                           disabled={true}
+                          fontScale={100}
                           message="w2"
+                          targetLanguageFontClassName=""
                         >
                           <ThemedTooltip
                             classes={
@@ -683,7 +724,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               }
                             }
                             disabled={true}
+                            fontScale={100}
                             message="w2"
+                            targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
                               PopperProps={
@@ -715,7 +758,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               leaveDelay={200}
                               title={
                                 <UNDEFINED>
-                                  w2
+                                  <span
+                                    style={
+                                      Object {
+                                        "fontSize": "100%",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className=""
+                                    >
+                                      w2
+                                    </span>
+                                  </span>
                                   <span
                                     className="ThemedTooltip-arrow-1"
                                   />
@@ -757,7 +812,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                 leaveDelay={200}
                                 title={
                                   <UNDEFINED>
-                                    w2
+                                    <span
+                                      style={
+                                        Object {
+                                          "fontSize": "100%",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className=""
+                                      >
+                                        w2
+                                      </span>
+                                    </span>
                                     <span
                                       className="ThemedTooltip-arrow-1"
                                     />
@@ -895,6 +962,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 <DragSource(SecondaryToken)
                   direction="ltr"
                   disabled={false}
+                  fontScale={100}
                   onClick={[Function]}
                   onEndDrag={[Function]}
                   selected={false}
@@ -913,6 +981,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     connectDragSource={[Function]}
                     direction="ltr"
                     disabled={false}
+                    fontScale={100}
                     isDragging={false}
                     isSelected={false}
                     onAccept={[Function]}
@@ -941,6 +1010,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                         direction="ltr"
                         disableTooltip={false}
                         disabled={false}
+                        fontScale={100}
                         isSuggestion={false}
                         occurrence={2}
                         occurrences={2}
@@ -956,7 +1026,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                       >
                         <WithStyles(ThemedTooltip)
                           disabled={true}
+                          fontScale={100}
                           message="w2"
+                          targetLanguageFontClassName=""
                         >
                           <ThemedTooltip
                             classes={
@@ -971,7 +1043,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               }
                             }
                             disabled={true}
+                            fontScale={100}
                             message="w2"
+                            targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
                               PopperProps={
@@ -1003,7 +1077,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               leaveDelay={200}
                               title={
                                 <UNDEFINED>
-                                  w2
+                                  <span
+                                    style={
+                                      Object {
+                                        "fontSize": "100%",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className=""
+                                    >
+                                      w2
+                                    </span>
+                                  </span>
                                   <span
                                     className="ThemedTooltip-arrow-1"
                                   />
@@ -1045,7 +1131,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                 leaveDelay={200}
                                 title={
                                   <UNDEFINED>
-                                    w2
+                                    <span
+                                      style={
+                                        Object {
+                                          "fontSize": "100%",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className=""
+                                      >
+                                        w2
+                                      </span>
+                                    </span>
                                     <span
                                       className="ThemedTooltip-arrow-1"
                                     />
@@ -1183,6 +1281,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 <DragSource(SecondaryToken)
                   direction="ltr"
                   disabled={true}
+                  fontScale={100}
                   onClick={[Function]}
                   onEndDrag={[Function]}
                   selected={false}
@@ -1201,6 +1300,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     connectDragSource={[Function]}
                     direction="ltr"
                     disabled={true}
+                    fontScale={100}
                     isDragging={false}
                     isSelected={false}
                     onAccept={[Function]}
@@ -1229,6 +1329,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                         direction="ltr"
                         disableTooltip={true}
                         disabled={true}
+                        fontScale={100}
                         isSuggestion={false}
                         occurrence={1}
                         occurrences={1}
@@ -1244,7 +1345,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                       >
                         <WithStyles(ThemedTooltip)
                           disabled={true}
+                          fontScale={100}
                           message="w3"
+                          targetLanguageFontClassName=""
                         >
                           <ThemedTooltip
                             classes={
@@ -1259,7 +1362,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               }
                             }
                             disabled={true}
+                            fontScale={100}
                             message="w3"
+                            targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
                               PopperProps={
@@ -1291,7 +1396,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               leaveDelay={200}
                               title={
                                 <UNDEFINED>
-                                  w3
+                                  <span
+                                    style={
+                                      Object {
+                                        "fontSize": "100%",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className=""
+                                    >
+                                      w3
+                                    </span>
+                                  </span>
                                   <span
                                     className="ThemedTooltip-arrow-1"
                                   />
@@ -1333,7 +1450,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                 leaveDelay={200}
                                 title={
                                   <UNDEFINED>
-                                    w3
+                                    <span
+                                      style={
+                                        Object {
+                                          "fontSize": "100%",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className=""
+                                      >
+                                        w3
+                                      </span>
+                                    </span>
                                     <span
                                       className="ThemedTooltip-arrow-1"
                                     />
@@ -1631,6 +1760,11 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
             onWordDragged={[Function]}
             selectedWordPositions={Array []}
             selectedWords={Array []}
+            toolSettings={
+              Object {
+                "fontSize": 100,
+              }
+            }
             toolsSettings={Object {}}
             verse={1}
             words={
@@ -1812,6 +1946,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 <DragSource(SecondaryToken)
                   direction="ltr"
                   disabled={false}
+                  fontScale={100}
                   onClick={[Function]}
                   onEndDrag={[Function]}
                   selected={false}
@@ -1830,6 +1965,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     connectDragSource={[Function]}
                     direction="ltr"
                     disabled={false}
+                    fontScale={100}
                     isDragging={false}
                     isSelected={false}
                     onAccept={[Function]}
@@ -1858,6 +1994,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                         direction="ltr"
                         disableTooltip={false}
                         disabled={false}
+                        fontScale={100}
                         isSuggestion={false}
                         occurrence={1}
                         occurrences={1}
@@ -1873,7 +2010,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                       >
                         <WithStyles(ThemedTooltip)
                           disabled={true}
+                          fontScale={100}
                           message="w1"
+                          targetLanguageFontClassName=""
                         >
                           <ThemedTooltip
                             classes={
@@ -1888,7 +2027,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               }
                             }
                             disabled={true}
+                            fontScale={100}
                             message="w1"
+                            targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
                               PopperProps={
@@ -1920,7 +2061,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               leaveDelay={200}
                               title={
                                 <UNDEFINED>
-                                  w1
+                                  <span
+                                    style={
+                                      Object {
+                                        "fontSize": "100%",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className=""
+                                    >
+                                      w1
+                                    </span>
+                                  </span>
                                   <span
                                     className="ThemedTooltip-arrow-1"
                                   />
@@ -1962,7 +2115,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                 leaveDelay={200}
                                 title={
                                   <UNDEFINED>
-                                    w1
+                                    <span
+                                      style={
+                                        Object {
+                                          "fontSize": "100%",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className=""
+                                      >
+                                        w1
+                                      </span>
+                                    </span>
                                     <span
                                       className="ThemedTooltip-arrow-1"
                                     />
@@ -2083,6 +2248,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 <DragSource(SecondaryToken)
                   direction="ltr"
                   disabled={false}
+                  fontScale={100}
                   onClick={[Function]}
                   onEndDrag={[Function]}
                   selected={false}
@@ -2101,6 +2267,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     connectDragSource={[Function]}
                     direction="ltr"
                     disabled={false}
+                    fontScale={100}
                     isDragging={false}
                     isSelected={false}
                     onAccept={[Function]}
@@ -2129,6 +2296,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                         direction="ltr"
                         disableTooltip={false}
                         disabled={false}
+                        fontScale={100}
                         isSuggestion={false}
                         occurrence={1}
                         occurrences={2}
@@ -2144,7 +2312,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                       >
                         <WithStyles(ThemedTooltip)
                           disabled={true}
+                          fontScale={100}
                           message="w2"
+                          targetLanguageFontClassName=""
                         >
                           <ThemedTooltip
                             classes={
@@ -2159,7 +2329,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               }
                             }
                             disabled={true}
+                            fontScale={100}
                             message="w2"
+                            targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
                               PopperProps={
@@ -2191,7 +2363,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               leaveDelay={200}
                               title={
                                 <UNDEFINED>
-                                  w2
+                                  <span
+                                    style={
+                                      Object {
+                                        "fontSize": "100%",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className=""
+                                    >
+                                      w2
+                                    </span>
+                                  </span>
                                   <span
                                     className="ThemedTooltip-arrow-1"
                                   />
@@ -2233,7 +2417,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                 leaveDelay={200}
                                 title={
                                   <UNDEFINED>
-                                    w2
+                                    <span
+                                      style={
+                                        Object {
+                                          "fontSize": "100%",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className=""
+                                      >
+                                        w2
+                                      </span>
+                                    </span>
                                     <span
                                       className="ThemedTooltip-arrow-1"
                                     />
@@ -2371,6 +2567,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 <DragSource(SecondaryToken)
                   direction="ltr"
                   disabled={false}
+                  fontScale={100}
                   onClick={[Function]}
                   onEndDrag={[Function]}
                   selected={false}
@@ -2389,6 +2586,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     connectDragSource={[Function]}
                     direction="ltr"
                     disabled={false}
+                    fontScale={100}
                     isDragging={false}
                     isSelected={false}
                     onAccept={[Function]}
@@ -2417,6 +2615,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                         direction="ltr"
                         disableTooltip={false}
                         disabled={false}
+                        fontScale={100}
                         isSuggestion={false}
                         occurrence={2}
                         occurrences={2}
@@ -2432,7 +2631,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                       >
                         <WithStyles(ThemedTooltip)
                           disabled={true}
+                          fontScale={100}
                           message="w2"
+                          targetLanguageFontClassName=""
                         >
                           <ThemedTooltip
                             classes={
@@ -2447,7 +2648,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               }
                             }
                             disabled={true}
+                            fontScale={100}
                             message="w2"
+                            targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
                               PopperProps={
@@ -2479,7 +2682,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               leaveDelay={200}
                               title={
                                 <UNDEFINED>
-                                  w2
+                                  <span
+                                    style={
+                                      Object {
+                                        "fontSize": "100%",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className=""
+                                    >
+                                      w2
+                                    </span>
+                                  </span>
                                   <span
                                     className="ThemedTooltip-arrow-1"
                                   />
@@ -2521,7 +2736,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                 leaveDelay={200}
                                 title={
                                   <UNDEFINED>
-                                    w2
+                                    <span
+                                      style={
+                                        Object {
+                                          "fontSize": "100%",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className=""
+                                      >
+                                        w2
+                                      </span>
+                                    </span>
                                     <span
                                       className="ThemedTooltip-arrow-1"
                                     />
@@ -2659,6 +2886,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                 <DragSource(SecondaryToken)
                   direction="ltr"
                   disabled={true}
+                  fontScale={100}
                   onClick={[Function]}
                   onEndDrag={[Function]}
                   selected={false}
@@ -2677,6 +2905,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                     connectDragSource={[Function]}
                     direction="ltr"
                     disabled={true}
+                    fontScale={100}
                     isDragging={false}
                     isSelected={false}
                     onAccept={[Function]}
@@ -2705,6 +2934,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                         direction="ltr"
                         disableTooltip={true}
                         disabled={true}
+                        fontScale={100}
                         isSuggestion={false}
                         occurrence={1}
                         occurrences={1}
@@ -2720,7 +2950,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                       >
                         <WithStyles(ThemedTooltip)
                           disabled={true}
+                          fontScale={100}
                           message="w3"
+                          targetLanguageFontClassName=""
                         >
                           <ThemedTooltip
                             classes={
@@ -2735,7 +2967,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               }
                             }
                             disabled={true}
+                            fontScale={100}
                             message="w3"
+                            targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
                               PopperProps={
@@ -2767,7 +3001,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               leaveDelay={200}
                               title={
                                 <UNDEFINED>
-                                  w3
+                                  <span
+                                    style={
+                                      Object {
+                                        "fontSize": "100%",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className=""
+                                    >
+                                      w3
+                                    </span>
+                                  </span>
                                   <span
                                     className="ThemedTooltip-arrow-1"
                                   />
@@ -2809,7 +3055,19 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                 leaveDelay={200}
                                 title={
                                   <UNDEFINED>
-                                    w3
+                                    <span
+                                      style={
+                                        Object {
+                                          "fontSize": "100%",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className=""
+                                      >
+                                        w3
+                                      </span>
+                                    </span>
                                     <span
                                       className="ThemedTooltip-arrow-1"
                                     />

--- a/src/components/WordList/index.js
+++ b/src/components/WordList/index.js
@@ -141,6 +141,7 @@ class DroppableWordList extends React.Component {
     return connectDropTarget(
       <div id='wordList' style={wordListStyle}>
         <WordList
+          toolSettings={toolsSettings['WordList']}
           verse={verse}
           words={words}
           isOver={isOver}


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Related to https://github.com/unfoldingword/translationcore/issues/7011
- fix tooltips displaying any time the mouse hovered over it.
- connected the new font size setting to wordbank tooltips so they scale as well.

#### Please include detailed Test instructions for your pull request:
-

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/wordalignment/284)
<!-- Reviewable:end -->
