### PR TITLE
Fixed overflowed occurrence number on wA tool word cards

### DIFF
--- a/src/components/AlignmentCard/__tests__/__snapshots__/AlignmentCard.test.js.snap
+++ b/src/components/AlignmentCard/__tests__/__snapshots__/AlignmentCard.test.js.snap
@@ -125,9 +125,9 @@ exports[`has a bottom word 1`] = `
             <sup
               style={
                 Object {
-                  "marginTop": "2px",
                   "opacity": "0.8",
-                  "top": 0,
+                  "padding": "2px 0px 0px",
+                  "top": "0px",
                 }
               }
             >
@@ -319,9 +319,9 @@ exports[`has a top and bottom word 1`] = `
             <sup
               style={
                 Object {
-                  "marginTop": "2px",
                   "opacity": "0.8",
-                  "top": 0,
+                  "padding": "2px 0px 0px",
+                  "top": "0px",
                 }
               }
             >
@@ -642,9 +642,9 @@ exports[`has multiple bottom words 1`] = `
             <sup
               style={
                 Object {
-                  "marginTop": "2px",
                   "opacity": "0.8",
-                  "top": 0,
+                  "padding": "2px 0px 0px",
+                  "top": "0px",
                 }
               }
             >
@@ -940,9 +940,9 @@ exports[`has multiple top and bottom words 1`] = `
             <sup
               style={
                 Object {
-                  "marginTop": "2px",
                   "opacity": "0.8",
-                  "top": 0,
+                  "padding": "2px 0px 0px",
+                  "top": "0px",
                 }
               }
             >

--- a/src/components/AlignmentCard/index.js
+++ b/src/components/AlignmentCard/index.js
@@ -121,6 +121,7 @@ class DroppableAlignmentCard extends Component {
       showPopover,
       getLexiconData,
       loadLexiconEntry,
+      fontSize,
       targetLanguageFontClassName,
     } = this.props;
     const acceptsTop = canDrop && dragItemType === types.PRIMARY_WORD;
@@ -134,15 +135,16 @@ class DroppableAlignmentCard extends Component {
     const topWordCards = sourceNgram.map((token, index) => (
       <PrimaryToken
         key={index}
-        style={sourceStyle}
-        translate={translate}
-        direction={sourceDirection}
-        wordIndex={index}
-        alignmentLength={sourceNgram.length}
         token={token}
-        alignmentIndex={alignmentIndex}
+        wordIndex={index}
+        style={sourceStyle}
         lexicons={lexicons}
         isHebrew={isHebrew}
+        fontSize={fontSize}
+        translate={translate}
+        direction={sourceDirection}
+        alignmentLength={sourceNgram.length}
+        alignmentIndex={alignmentIndex}
         showPopover={showPopover}
         getLexiconData={getLexiconData}
         loadLexiconEntry={loadLexiconEntry}
@@ -153,10 +155,10 @@ class DroppableAlignmentCard extends Component {
         key={index}
         token={token}
         direction={targetDirection}
-        targetLanguageFontClassName={targetLanguageFontClassName}
+        alignmentIndex={alignmentIndex}
         onCancel={this._handleCancelSuggestion}
         onAccept={this._handleAcceptSuggestion}
-        alignmentIndex={alignmentIndex}
+        targetLanguageFontClassName={targetLanguageFontClassName}
       />
     ));
 
@@ -180,6 +182,7 @@ class DroppableAlignmentCard extends Component {
 }
 
 DroppableAlignmentCard.propTypes = {
+  fontSize: PropTypes.string,
   onCancelTokenSuggestion: PropTypes.func,
   onAcceptTokenSuggestion: PropTypes.func,
   translate: PropTypes.func.isRequired,

--- a/src/components/AlignmentGrid.js
+++ b/src/components/AlignmentGrid.js
@@ -96,6 +96,7 @@ class AlignmentGrid extends Component {
                 showPopover={showPopover}
                 getLexiconData={getLexiconData}
                 loadLexiconEntry={loadLexiconEntry}
+                fontSize={fontSize}
                 targetLanguageFontClassName={targetLanguageFontClassName}
               />
               {/* placeholder for un-merging primary words */}
@@ -114,6 +115,7 @@ class AlignmentGrid extends Component {
                 loadLexiconEntry={loadLexiconEntry}
                 lexicons={lexicons}
                 isHebrew={isHebrew}
+                fontSize={fontSize}
                 targetLanguageFontClassName={targetLanguageFontClassName}
               />
             </React.Fragment>

--- a/src/components/PrimaryToken.js
+++ b/src/components/PrimaryToken.js
@@ -62,23 +62,28 @@ class PrimaryToken extends Component {
     const {
       token,
       style,
-      isDragging,
-      direction,
       canDrag,
-      connectDragSource,
+      fontSize,
+      isHebrew,
+      direction,
+      isDragging,
       dragPreview,
+      connectDragSource,
     } = this.props;
     const { hover } = this.state;
 
     const disabled = (isDragging || hover) && !canDrag;
     const word = dragPreview(
       <div>
-        <Word word={token.text}
-          direction={direction}
+        <Word
+          word={token.text}
           disabled={disabled}
-          style={{ ...internalStyle.word, ...style }}
+          fontSize={fontSize}
+          isHebrew={isHebrew}
+          direction={direction}
           occurrence={token.occurrence}
           occurrences={token.occurrences}
+          style={{ ...internalStyle.word, ...style }}
         />
       </div>
     );
@@ -116,6 +121,7 @@ class PrimaryToken extends Component {
 }
 
 PrimaryToken.propTypes = {
+  fontSize: PropTypes.string,
   translate: PropTypes.func.isRequired,
   wordIndex: PropTypes.number,
   alignmentLength: PropTypes.number,

--- a/src/components/WordCard/WordOccurrence.js
+++ b/src/components/WordCard/WordOccurrence.js
@@ -2,9 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const styles = {
-  top: 0,
-  marginTop: '2px',
-  opacity: '0.8'
+  top: 7,
+  opacity: '0.8',
+  marginTop: '5px',
+  marginRight: '10px',
+  padding: '2px 0px 0px 0px',
 };
 
 /**

--- a/src/components/WordCard/WordOccurrence.js
+++ b/src/components/WordCard/WordOccurrence.js
@@ -1,12 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const styles = {
+const regularHebrewStyles = {
+  top: 0,
+  opacity: '0.8',
+  marginTop: '5.5px',
+};
+
+const largeHebrewStyles = {
   top: 7,
   opacity: '0.8',
   marginTop: '5px',
   marginRight: '10px',
   padding: '2px 0px 0px 0px',
+};
+
+const regularGreekStyles = {
+  top: '0px',
+  opacity: '0.8',
+};
+
+const largeGreekStyles = {
+  top: '0px',
+  opacity: '0.8',
+  padding: '2px 0px 0px',
 };
 
 /**
@@ -18,11 +35,26 @@ const styles = {
  * @return {*}
  * @constructor
  */
-const WordOccurrence = ({occurrence, occurrences, style}) => {
+const WordOccurrence = ({
+  style,
+  fontSize,
+  isHebrew,
+  occurrence,
+  occurrences,
+}) => {
+  let styles = {};
+
+  if (isHebrew) {
+    styles = fontSize <= 100 ? regularHebrewStyles : largeHebrewStyles;
+  } else { // is Greek
+    styles = fontSize <= 100 ? regularGreekStyles : largeGreekStyles;
+  }
+
   const computedStyles = {
     ...styles,
     ...style
   };
+
   if (occurrences > 1) {
     return <sup style={computedStyles}>{occurrence}</sup>;
   } else {
@@ -31,9 +63,11 @@ const WordOccurrence = ({occurrence, occurrences, style}) => {
 };
 
 WordOccurrence.propTypes = {
+  style: PropTypes.object,
+  isHebrew: PropTypes.bool,
+  fontSize: PropTypes.string,
   occurrence: PropTypes.number.isRequired,
   occurrences: PropTypes.number.isRequired,
-  style: PropTypes.object
 };
 
 export default WordOccurrence;

--- a/src/components/WordCard/__tests__/__snapshots__/WordCard.test.js.snap
+++ b/src/components/WordCard/__tests__/__snapshots__/WordCard.test.js.snap
@@ -81,9 +81,9 @@ exports[`is a suggestion 1`] = `
     <sup
       style={
         Object {
-          "marginTop": "2px",
           "opacity": "0.8",
-          "top": 0,
+          "padding": "2px 0px 0px",
+          "top": "0px",
         }
       }
     >
@@ -147,9 +147,9 @@ exports[`occurs multiple times 1`] = `
     <sup
       style={
         Object {
-          "marginTop": "2px",
           "opacity": "0.8",
-          "top": 0,
+          "padding": "2px 0px 0px",
+          "top": "0px",
         }
       }
     >

--- a/src/components/WordCard/index.js
+++ b/src/components/WordCard/index.js
@@ -143,12 +143,12 @@ class WordCard extends React.Component {
   render() {
     const {
       word,
+      fontScale,
       occurrence,
       occurrences,
       isSuggestion,
       disableTooltip,
       targetLanguageFontClassName,
-      fontScale
     } = this.props;
     const styles = makeStyles(this.props);
     const { tooltip } = this.state;
@@ -163,8 +163,8 @@ class WordCard extends React.Component {
                 <span
                   ref={this.wordRef}
                   style={styles.word}
-                  className={targetLanguageFontClassName}
                   onClick={this._handleClick}
+                  className={targetLanguageFontClassName}
                 >
                   {word}
                 </span>

--- a/src/components/WordCard/index.js
+++ b/src/components/WordCard/index.js
@@ -143,6 +143,8 @@ class WordCard extends React.Component {
   render() {
     const {
       word,
+      fontSize,
+      isHebrew,
       fontScale,
       occurrence,
       occurrences,
@@ -173,8 +175,12 @@ class WordCard extends React.Component {
                 ) : null}
 
               </span>
-              <WordOccurrence occurrence={occurrence}
-                              occurrences={occurrences}/>
+              <WordOccurrence
+                fontSize={fontSize}
+                isHebrew={isHebrew}
+                occurrence={occurrence}
+                occurrences={occurrences}
+              />
             </div>
           </div>
         </ThemedTooltip>
@@ -184,6 +190,8 @@ class WordCard extends React.Component {
 }
 
 WordCard.propTypes = {
+  isHebrew: PropTypes.bool,
+  fontSize: PropTypes.string,
   disableTooltip: PropTypes.bool,
   selected: PropTypes.bool,
   disabled: PropTypes.bool,

--- a/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
+++ b/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
@@ -891,9 +891,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       <sup
                                         style={
                                           Object {
-                                            "marginTop": "2px",
                                             "opacity": "0.8",
-                                            "top": 0,
+                                            "padding": "2px 0px 0px",
+                                            "top": "0px",
                                           }
                                         }
                                       >
@@ -921,7 +921,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                           </span>
                                         </span>
                                         <sup
-                                          style="top: 0px; margin-top: 2px; opacity: 0.8;"
+                                          style="top: 0px; opacity: 0.8; padding: 2px 0px 0px;"
                                         >
                                           1
                                         </sup>
@@ -1210,9 +1210,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       <sup
                                         style={
                                           Object {
-                                            "marginTop": "2px",
                                             "opacity": "0.8",
-                                            "top": 0,
+                                            "padding": "2px 0px 0px",
+                                            "top": "0px",
                                           }
                                         }
                                       >
@@ -1240,7 +1240,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                           </span>
                                         </span>
                                         <sup
-                                          style="top: 0px; margin-top: 2px; opacity: 0.8;"
+                                          style="top: 0px; opacity: 0.8; padding: 2px 0px 0px;"
                                         >
                                           2
                                         </sup>
@@ -2498,9 +2498,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       <sup
                                         style={
                                           Object {
-                                            "marginTop": "2px",
                                             "opacity": "0.8",
-                                            "top": 0,
+                                            "padding": "2px 0px 0px",
+                                            "top": "0px",
                                           }
                                         }
                                       >
@@ -2528,7 +2528,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                           </span>
                                         </span>
                                         <sup
-                                          style="top: 0px; margin-top: 2px; opacity: 0.8;"
+                                          style="top: 0px; opacity: 0.8; padding: 2px 0px 0px;"
                                         >
                                           1
                                         </sup>
@@ -2817,9 +2817,9 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       <sup
                                         style={
                                           Object {
-                                            "marginTop": "2px",
                                             "opacity": "0.8",
-                                            "top": 0,
+                                            "padding": "2px 0px 0px",
+                                            "top": "0px",
                                           }
                                         }
                                       >
@@ -2847,7 +2847,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                           </span>
                                         </span>
                                         <sup
-                                          style="top: 0px; margin-top: 2px; opacity: 0.8;"
+                                          style="top: 0px; opacity: 0.8; padding: 2px 0px 0px;"
                                         >
                                           2
                                         </sup>


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
-

#### Please include detailed Test instructions for your pull request:
- checkout `bugfix-mannycolon-7033` branch in wa submodule
- verify that the word occurrence number in the word cards don't overflow when resizing the text in the alignment grid

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/wordalignment/293)
<!-- Reviewable:end -->
