### PR TITLE
Bugfix 7034/fix arrow on word bank item hover - should not move

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11919,9 +11919,9 @@
       }
     },
     "tc-ui-toolkit": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-5.3.0.tgz",
-      "integrity": "sha512-89mOCHmasSj7l2sm7oVWjqeGYvp9dJPA8SIEdimDhdi67Ac9LulOEckcuBV414zaxfT79ukV8dX94QVWHI9Sng==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/tc-ui-toolkit/-/tc-ui-toolkit-5.3.1.tgz",
+      "integrity": "sha512-lPEGyEpu3h86LqXkB77r8u94msflu35gfyZw4adOllBWMgb8561MdCr7p25GlvzJCjMIWpTTuXDFKkEK90AM/g==",
       "requires": {
         "@material-ui/core": "^4.10.2",
         "@material-ui/icons": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "simple-git": "^1.131.0",
     "tc-electron-env": "0.9.0",
     "tc-tool": "3.0.3",
-    "tc-ui-toolkit": "5.3.0",
+    "tc-ui-toolkit": "5.3.1",
     "usfm-js": "1.0.6",
     "word-aligner": "0.2.12",
     "wordmap": "^0.4.3",

--- a/src/components/ThemedTooltip.js
+++ b/src/components/ThemedTooltip.js
@@ -3,53 +3,6 @@ import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Tooltip from '@material-ui/core/Tooltip';
 
-function arrowGenerator(color) {
-  return {
-    '&[x-placement*="bottom"] $arrow': {
-      top: 8,
-      left: 0,
-      marginTop: '-0.95em',
-      width: '3em',
-      height: '1em',
-      '&::before': {
-        borderWidth: '0 1em 1em 1em',
-        borderColor: `transparent transparent ${color} transparent`,
-      },
-    },
-    '&[x-placement*="top"] $arrow': {
-      bottom: 0,
-      left: 0,
-      marginBottom: '-0.95em',
-      width: '3em',
-      height: '1em',
-      '&::before': {
-        borderWidth: '1em 1em 0 1em',
-        borderColor: `${color} transparent transparent transparent`,
-      },
-    },
-    '&[x-placement*="right"] $arrow': {
-      left: 0,
-      marginLeft: '-0.95em',
-      height: '3em',
-      width: '1em',
-      '&::before': {
-        borderWidth: '1em 1em 1em 0',
-        borderColor: `transparent ${color} transparent transparent`,
-      },
-    },
-    '&[x-placement*="left"] $arrow': {
-      right: 0,
-      marginRight: '-0.95em',
-      height: '3em',
-      width: '1em',
-      '&::before': {
-        borderWidth: '1em 0 1em 1em',
-        borderColor: `transparent transparent transparent ${color}`,
-      },
-    },
-  };
-}
-
 const styles = theme => ({
   arrow: {
     'fontSize': 16,
@@ -60,21 +13,6 @@ const styles = theme => ({
       boxSizing: 'border-box',
     },
   },
-  // arrow: {
-  //   position: 'absolute',
-  //   fontSize: 6,
-  //   width: '3em',
-  //   height: '3em',
-  //   '&::before': {
-  //     content: '""',
-  //     margin: 'auto',
-  //     display: 'block',
-  //     width: 0,
-  //     height: 0,
-  //     borderStyle: 'solid',
-  //   },
-  // },
-  bootstrapPopper: arrowGenerator(theme.palette.common.black),
   bootstrapTooltip: {
     backgroundColor: theme.palette.common.black,
     fontSize: "inherit",
@@ -82,18 +20,6 @@ const styles = theme => ({
     maxWidth: 375,
     wordBreak: "break-all"
   },
-  bootstrapPlacementLeft: {
-    margin: '0 8px',
-  },
-  bootstrapPlacementRight: {
-    margin: '0 8px',
-  },
-  bootstrapPlacementTop: {
-    margin: '8px 0',
-  },
-  bootstrapPlacementBottom: {
-    margin: '8px 0',
-  }
 });
 
 /**
@@ -123,7 +49,6 @@ class ThemedTooltip extends React.Component {
 
   render() {
     const { message , children, classes, disabled, targetLanguageFontClassName, fontScale} = this.props;
-    const { arrowRef } = this.state;
 
     return (
       <Tooltip
@@ -134,22 +59,15 @@ class ThemedTooltip extends React.Component {
         enterDelay={400}
         leaveDelay={200}
         title={
-          // <React.Fragment>
           <span style={{fontSize: `${fontScale}%`}}>
             <span className={targetLanguageFontClassName}>
               {message}
             </span>
           </span>
-        //     <span className={classes.arrow} ref={this.handleArrowRef} />
-        //   </React.Fragment>
         }
         classes={{
           tooltip: classes.bootstrapTooltip,
           arrow: classes.arrow,
-          tooltipPlacementLeft: classes.bootstrapPlacementLeft,
-          tooltipPlacementRight: classes.bootstrapPlacementRight,
-          tooltipPlacementTop: classes.bootstrapPlacementTop,
-          tooltipPlacementBottom: classes.bootstrapPlacementBottom,
         }}
       >
         {children}

--- a/src/components/ThemedTooltip.js
+++ b/src/components/ThemedTooltip.js
@@ -52,19 +52,28 @@ function arrowGenerator(color) {
 
 const styles = theme => ({
   arrow: {
-    position: 'absolute',
-    fontSize: 6,
-    width: '3em',
-    height: '3em',
+    'fontSize': 16,
+    'width': 17,
     '&::before': {
-      content: '""',
-      margin: 'auto',
-      display: 'block',
-      width: 0,
-      height: 0,
-      borderStyle: 'solid',
+      border: '1px solid #000',
+      backgroundColor: theme.palette.common.black,
+      boxSizing: 'border-box',
     },
   },
+  // arrow: {
+  //   position: 'absolute',
+  //   fontSize: 6,
+  //   width: '3em',
+  //   height: '3em',
+  //   '&::before': {
+  //     content: '""',
+  //     margin: 'auto',
+  //     display: 'block',
+  //     width: 0,
+  //     height: 0,
+  //     borderStyle: 'solid',
+  //   },
+  // },
   bootstrapPopper: arrowGenerator(theme.palette.common.black),
   bootstrapTooltip: {
     backgroundColor: theme.palette.common.black,
@@ -118,38 +127,29 @@ class ThemedTooltip extends React.Component {
 
     return (
       <Tooltip
+        arrow={true}
         disableFocusListener={disabled}
         disableHoverListener={disabled}
         disableTouchListener={disabled}
         enterDelay={400}
         leaveDelay={200}
         title={
-          <React.Fragment>
-            <span style={{fontSize: `${fontScale}%`}}>
-              <span className={targetLanguageFontClassName}>
-                {message}
-              </span>
+          // <React.Fragment>
+          <span style={{fontSize: `${fontScale}%`}}>
+            <span className={targetLanguageFontClassName}>
+              {message}
             </span>
-            <span className={classes.arrow} ref={this.handleArrowRef} />
-          </React.Fragment>
+          </span>
+        //     <span className={classes.arrow} ref={this.handleArrowRef} />
+        //   </React.Fragment>
         }
         classes={{
           tooltip: classes.bootstrapTooltip,
-          popper: classes.bootstrapPopper,
+          arrow: classes.arrow,
           tooltipPlacementLeft: classes.bootstrapPlacementLeft,
           tooltipPlacementRight: classes.bootstrapPlacementRight,
           tooltipPlacementTop: classes.bootstrapPlacementTop,
           tooltipPlacementBottom: classes.bootstrapPlacementBottom,
-        }}
-        PopperProps={{
-          popperOptions: {
-            modifiers: {
-              arrow: {
-                enabled: Boolean(arrowRef),
-                element: arrowRef,
-              },
-            },
-          },
         }}
       >
         {children}

--- a/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
+++ b/src/components/WordList/__tests__/__snapshots__/DroppableWordList.test.js.snap
@@ -415,12 +415,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             classes={
                               Object {
                                 "arrow": "ThemedTooltip-arrow-1",
-                                "bootstrapPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                "bootstrapPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                "bootstrapPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                "bootstrapPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
-                                "bootstrapPopper": "ThemedTooltip-bootstrapPopper-2",
-                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-3",
+                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-2",
                               }
                             }
                             disabled={true}
@@ -429,26 +424,11 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
-                              PopperProps={
-                                Object {
-                                  "popperOptions": Object {
-                                    "modifiers": Object {
-                                      "arrow": Object {
-                                        "element": null,
-                                        "enabled": false,
-                                      },
-                                    },
-                                  },
-                                }
-                              }
+                              arrow={true}
                               classes={
                                 Object {
-                                  "popper": "ThemedTooltip-bootstrapPopper-2",
-                                  "tooltip": "ThemedTooltip-bootstrapTooltip-3",
-                                  "tooltipPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                  "tooltipPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                  "tooltipPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                  "tooltipPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
+                                  "arrow": "ThemedTooltip-arrow-1",
+                                  "tooltip": "ThemedTooltip-bootstrapTooltip-2",
                                 }
                               }
                               disableFocusListener={true}
@@ -457,7 +437,44 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               enterDelay={400}
                               leaveDelay={200}
                               title={
-                                <UNDEFINED>
+                                <span
+                                  style={
+                                    Object {
+                                      "fontSize": "100%",
+                                    }
+                                  }
+                                >
+                                  <span
+                                    className=""
+                                  >
+                                    w1
+                                  </span>
+                                </span>
+                              }
+                            >
+                              <ForwardRef(Tooltip)
+                                arrow={true}
+                                classes={
+                                  Object {
+                                    "arrow": "MuiTooltip-arrow ThemedTooltip-arrow-1",
+                                    "popper": "MuiTooltip-popper",
+                                    "popperArrow": "MuiTooltip-popperArrow",
+                                    "popperInteractive": "MuiTooltip-popperInteractive",
+                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-2",
+                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
+                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
+                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
+                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
+                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop",
+                                    "touch": "MuiTooltip-touch",
+                                  }
+                                }
+                                disableFocusListener={true}
+                                disableHoverListener={true}
+                                disableTouchListener={true}
+                                enterDelay={400}
+                                leaveDelay={200}
+                                title={
                                   <span
                                     style={
                                       Object {
@@ -471,64 +488,6 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       w1
                                     </span>
                                   </span>
-                                  <span
-                                    className="ThemedTooltip-arrow-1"
-                                  />
-                                </UNDEFINED>
-                              }
-                            >
-                              <ForwardRef(Tooltip)
-                                PopperProps={
-                                  Object {
-                                    "popperOptions": Object {
-                                      "modifiers": Object {
-                                        "arrow": Object {
-                                          "element": null,
-                                          "enabled": false,
-                                        },
-                                      },
-                                    },
-                                  }
-                                }
-                                classes={
-                                  Object {
-                                    "arrow": "MuiTooltip-arrow",
-                                    "popper": "MuiTooltip-popper ThemedTooltip-bootstrapPopper-2",
-                                    "popperArrow": "MuiTooltip-popperArrow",
-                                    "popperInteractive": "MuiTooltip-popperInteractive",
-                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-3",
-                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
-                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom ThemedTooltip-bootstrapPlacementBottom-7",
-                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft ThemedTooltip-bootstrapPlacementLeft-4",
-                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight ThemedTooltip-bootstrapPlacementRight-5",
-                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop ThemedTooltip-bootstrapPlacementTop-6",
-                                    "touch": "MuiTooltip-touch",
-                                  }
-                                }
-                                disableFocusListener={true}
-                                disableHoverListener={true}
-                                disableTouchListener={true}
-                                enterDelay={400}
-                                leaveDelay={200}
-                                title={
-                                  <UNDEFINED>
-                                    <span
-                                      style={
-                                        Object {
-                                          "fontSize": "100%",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className=""
-                                      >
-                                        w1
-                                      </span>
-                                    </span>
-                                    <span
-                                      className="ThemedTooltip-arrow-1"
-                                    />
-                                  </UNDEFINED>
                                 }
                               >
                                 <div
@@ -609,7 +568,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       </div>
                                     </div>
                                   }
-                                  className="MuiTooltip-popper ThemedTooltip-bootstrapPopper-2"
+                                  className="MuiTooltip-popper MuiTooltip-popperArrow"
                                   id={null}
                                   open={false}
                                   placement="bottom"
@@ -717,12 +676,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             classes={
                               Object {
                                 "arrow": "ThemedTooltip-arrow-1",
-                                "bootstrapPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                "bootstrapPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                "bootstrapPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                "bootstrapPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
-                                "bootstrapPopper": "ThemedTooltip-bootstrapPopper-2",
-                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-3",
+                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-2",
                               }
                             }
                             disabled={true}
@@ -731,26 +685,11 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
-                              PopperProps={
-                                Object {
-                                  "popperOptions": Object {
-                                    "modifiers": Object {
-                                      "arrow": Object {
-                                        "element": null,
-                                        "enabled": false,
-                                      },
-                                    },
-                                  },
-                                }
-                              }
+                              arrow={true}
                               classes={
                                 Object {
-                                  "popper": "ThemedTooltip-bootstrapPopper-2",
-                                  "tooltip": "ThemedTooltip-bootstrapTooltip-3",
-                                  "tooltipPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                  "tooltipPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                  "tooltipPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                  "tooltipPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
+                                  "arrow": "ThemedTooltip-arrow-1",
+                                  "tooltip": "ThemedTooltip-bootstrapTooltip-2",
                                 }
                               }
                               disableFocusListener={true}
@@ -759,7 +698,44 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               enterDelay={400}
                               leaveDelay={200}
                               title={
-                                <UNDEFINED>
+                                <span
+                                  style={
+                                    Object {
+                                      "fontSize": "100%",
+                                    }
+                                  }
+                                >
+                                  <span
+                                    className=""
+                                  >
+                                    w2
+                                  </span>
+                                </span>
+                              }
+                            >
+                              <ForwardRef(Tooltip)
+                                arrow={true}
+                                classes={
+                                  Object {
+                                    "arrow": "MuiTooltip-arrow ThemedTooltip-arrow-1",
+                                    "popper": "MuiTooltip-popper",
+                                    "popperArrow": "MuiTooltip-popperArrow",
+                                    "popperInteractive": "MuiTooltip-popperInteractive",
+                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-2",
+                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
+                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
+                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
+                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
+                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop",
+                                    "touch": "MuiTooltip-touch",
+                                  }
+                                }
+                                disableFocusListener={true}
+                                disableHoverListener={true}
+                                disableTouchListener={true}
+                                enterDelay={400}
+                                leaveDelay={200}
+                                title={
                                   <span
                                     style={
                                       Object {
@@ -773,64 +749,6 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       w2
                                     </span>
                                   </span>
-                                  <span
-                                    className="ThemedTooltip-arrow-1"
-                                  />
-                                </UNDEFINED>
-                              }
-                            >
-                              <ForwardRef(Tooltip)
-                                PopperProps={
-                                  Object {
-                                    "popperOptions": Object {
-                                      "modifiers": Object {
-                                        "arrow": Object {
-                                          "element": null,
-                                          "enabled": false,
-                                        },
-                                      },
-                                    },
-                                  }
-                                }
-                                classes={
-                                  Object {
-                                    "arrow": "MuiTooltip-arrow",
-                                    "popper": "MuiTooltip-popper ThemedTooltip-bootstrapPopper-2",
-                                    "popperArrow": "MuiTooltip-popperArrow",
-                                    "popperInteractive": "MuiTooltip-popperInteractive",
-                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-3",
-                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
-                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom ThemedTooltip-bootstrapPlacementBottom-7",
-                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft ThemedTooltip-bootstrapPlacementLeft-4",
-                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight ThemedTooltip-bootstrapPlacementRight-5",
-                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop ThemedTooltip-bootstrapPlacementTop-6",
-                                    "touch": "MuiTooltip-touch",
-                                  }
-                                }
-                                disableFocusListener={true}
-                                disableHoverListener={true}
-                                disableTouchListener={true}
-                                enterDelay={400}
-                                leaveDelay={200}
-                                title={
-                                  <UNDEFINED>
-                                    <span
-                                      style={
-                                        Object {
-                                          "fontSize": "100%",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className=""
-                                      >
-                                        w2
-                                      </span>
-                                    </span>
-                                    <span
-                                      className="ThemedTooltip-arrow-1"
-                                    />
-                                  </UNDEFINED>
                                 }
                               >
                                 <div
@@ -928,7 +846,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       </div>
                                     </div>
                                   }
-                                  className="MuiTooltip-popper ThemedTooltip-bootstrapPopper-2"
+                                  className="MuiTooltip-popper MuiTooltip-popperArrow"
                                   id={null}
                                   open={false}
                                   placement="bottom"
@@ -1036,12 +954,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             classes={
                               Object {
                                 "arrow": "ThemedTooltip-arrow-1",
-                                "bootstrapPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                "bootstrapPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                "bootstrapPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                "bootstrapPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
-                                "bootstrapPopper": "ThemedTooltip-bootstrapPopper-2",
-                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-3",
+                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-2",
                               }
                             }
                             disabled={true}
@@ -1050,26 +963,11 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
-                              PopperProps={
-                                Object {
-                                  "popperOptions": Object {
-                                    "modifiers": Object {
-                                      "arrow": Object {
-                                        "element": null,
-                                        "enabled": false,
-                                      },
-                                    },
-                                  },
-                                }
-                              }
+                              arrow={true}
                               classes={
                                 Object {
-                                  "popper": "ThemedTooltip-bootstrapPopper-2",
-                                  "tooltip": "ThemedTooltip-bootstrapTooltip-3",
-                                  "tooltipPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                  "tooltipPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                  "tooltipPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                  "tooltipPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
+                                  "arrow": "ThemedTooltip-arrow-1",
+                                  "tooltip": "ThemedTooltip-bootstrapTooltip-2",
                                 }
                               }
                               disableFocusListener={true}
@@ -1078,7 +976,44 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               enterDelay={400}
                               leaveDelay={200}
                               title={
-                                <UNDEFINED>
+                                <span
+                                  style={
+                                    Object {
+                                      "fontSize": "100%",
+                                    }
+                                  }
+                                >
+                                  <span
+                                    className=""
+                                  >
+                                    w2
+                                  </span>
+                                </span>
+                              }
+                            >
+                              <ForwardRef(Tooltip)
+                                arrow={true}
+                                classes={
+                                  Object {
+                                    "arrow": "MuiTooltip-arrow ThemedTooltip-arrow-1",
+                                    "popper": "MuiTooltip-popper",
+                                    "popperArrow": "MuiTooltip-popperArrow",
+                                    "popperInteractive": "MuiTooltip-popperInteractive",
+                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-2",
+                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
+                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
+                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
+                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
+                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop",
+                                    "touch": "MuiTooltip-touch",
+                                  }
+                                }
+                                disableFocusListener={true}
+                                disableHoverListener={true}
+                                disableTouchListener={true}
+                                enterDelay={400}
+                                leaveDelay={200}
+                                title={
                                   <span
                                     style={
                                       Object {
@@ -1092,64 +1027,6 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       w2
                                     </span>
                                   </span>
-                                  <span
-                                    className="ThemedTooltip-arrow-1"
-                                  />
-                                </UNDEFINED>
-                              }
-                            >
-                              <ForwardRef(Tooltip)
-                                PopperProps={
-                                  Object {
-                                    "popperOptions": Object {
-                                      "modifiers": Object {
-                                        "arrow": Object {
-                                          "element": null,
-                                          "enabled": false,
-                                        },
-                                      },
-                                    },
-                                  }
-                                }
-                                classes={
-                                  Object {
-                                    "arrow": "MuiTooltip-arrow",
-                                    "popper": "MuiTooltip-popper ThemedTooltip-bootstrapPopper-2",
-                                    "popperArrow": "MuiTooltip-popperArrow",
-                                    "popperInteractive": "MuiTooltip-popperInteractive",
-                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-3",
-                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
-                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom ThemedTooltip-bootstrapPlacementBottom-7",
-                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft ThemedTooltip-bootstrapPlacementLeft-4",
-                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight ThemedTooltip-bootstrapPlacementRight-5",
-                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop ThemedTooltip-bootstrapPlacementTop-6",
-                                    "touch": "MuiTooltip-touch",
-                                  }
-                                }
-                                disableFocusListener={true}
-                                disableHoverListener={true}
-                                disableTouchListener={true}
-                                enterDelay={400}
-                                leaveDelay={200}
-                                title={
-                                  <UNDEFINED>
-                                    <span
-                                      style={
-                                        Object {
-                                          "fontSize": "100%",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className=""
-                                      >
-                                        w2
-                                      </span>
-                                    </span>
-                                    <span
-                                      className="ThemedTooltip-arrow-1"
-                                    />
-                                  </UNDEFINED>
                                 }
                               >
                                 <div
@@ -1247,7 +1124,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       </div>
                                     </div>
                                   }
-                                  className="MuiTooltip-popper ThemedTooltip-bootstrapPopper-2"
+                                  className="MuiTooltip-popper MuiTooltip-popperArrow"
                                   id={null}
                                   open={false}
                                   placement="bottom"
@@ -1355,12 +1232,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             classes={
                               Object {
                                 "arrow": "ThemedTooltip-arrow-1",
-                                "bootstrapPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                "bootstrapPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                "bootstrapPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                "bootstrapPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
-                                "bootstrapPopper": "ThemedTooltip-bootstrapPopper-2",
-                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-3",
+                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-2",
                               }
                             }
                             disabled={true}
@@ -1369,26 +1241,11 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
-                              PopperProps={
-                                Object {
-                                  "popperOptions": Object {
-                                    "modifiers": Object {
-                                      "arrow": Object {
-                                        "element": null,
-                                        "enabled": false,
-                                      },
-                                    },
-                                  },
-                                }
-                              }
+                              arrow={true}
                               classes={
                                 Object {
-                                  "popper": "ThemedTooltip-bootstrapPopper-2",
-                                  "tooltip": "ThemedTooltip-bootstrapTooltip-3",
-                                  "tooltipPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                  "tooltipPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                  "tooltipPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                  "tooltipPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
+                                  "arrow": "ThemedTooltip-arrow-1",
+                                  "tooltip": "ThemedTooltip-bootstrapTooltip-2",
                                 }
                               }
                               disableFocusListener={true}
@@ -1397,7 +1254,44 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               enterDelay={400}
                               leaveDelay={200}
                               title={
-                                <UNDEFINED>
+                                <span
+                                  style={
+                                    Object {
+                                      "fontSize": "100%",
+                                    }
+                                  }
+                                >
+                                  <span
+                                    className=""
+                                  >
+                                    w3
+                                  </span>
+                                </span>
+                              }
+                            >
+                              <ForwardRef(Tooltip)
+                                arrow={true}
+                                classes={
+                                  Object {
+                                    "arrow": "MuiTooltip-arrow ThemedTooltip-arrow-1",
+                                    "popper": "MuiTooltip-popper",
+                                    "popperArrow": "MuiTooltip-popperArrow",
+                                    "popperInteractive": "MuiTooltip-popperInteractive",
+                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-2",
+                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
+                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
+                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
+                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
+                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop",
+                                    "touch": "MuiTooltip-touch",
+                                  }
+                                }
+                                disableFocusListener={true}
+                                disableHoverListener={true}
+                                disableTouchListener={true}
+                                enterDelay={400}
+                                leaveDelay={200}
+                                title={
                                   <span
                                     style={
                                       Object {
@@ -1411,64 +1305,6 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       w3
                                     </span>
                                   </span>
-                                  <span
-                                    className="ThemedTooltip-arrow-1"
-                                  />
-                                </UNDEFINED>
-                              }
-                            >
-                              <ForwardRef(Tooltip)
-                                PopperProps={
-                                  Object {
-                                    "popperOptions": Object {
-                                      "modifiers": Object {
-                                        "arrow": Object {
-                                          "element": null,
-                                          "enabled": false,
-                                        },
-                                      },
-                                    },
-                                  }
-                                }
-                                classes={
-                                  Object {
-                                    "arrow": "MuiTooltip-arrow",
-                                    "popper": "MuiTooltip-popper ThemedTooltip-bootstrapPopper-2",
-                                    "popperArrow": "MuiTooltip-popperArrow",
-                                    "popperInteractive": "MuiTooltip-popperInteractive",
-                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-3",
-                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
-                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom ThemedTooltip-bootstrapPlacementBottom-7",
-                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft ThemedTooltip-bootstrapPlacementLeft-4",
-                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight ThemedTooltip-bootstrapPlacementRight-5",
-                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop ThemedTooltip-bootstrapPlacementTop-6",
-                                    "touch": "MuiTooltip-touch",
-                                  }
-                                }
-                                disableFocusListener={true}
-                                disableHoverListener={true}
-                                disableTouchListener={true}
-                                enterDelay={400}
-                                leaveDelay={200}
-                                title={
-                                  <UNDEFINED>
-                                    <span
-                                      style={
-                                        Object {
-                                          "fontSize": "100%",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className=""
-                                      >
-                                        w3
-                                      </span>
-                                    </span>
-                                    <span
-                                      className="ThemedTooltip-arrow-1"
-                                    />
-                                  </UNDEFINED>
                                 }
                               >
                                 <div
@@ -1550,7 +1386,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       </div>
                                     </div>
                                   }
-                                  className="MuiTooltip-popper ThemedTooltip-bootstrapPopper-2"
+                                  className="MuiTooltip-popper MuiTooltip-popperArrow"
                                   id={null}
                                   open={false}
                                   placement="bottom"
@@ -2022,12 +1858,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             classes={
                               Object {
                                 "arrow": "ThemedTooltip-arrow-1",
-                                "bootstrapPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                "bootstrapPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                "bootstrapPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                "bootstrapPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
-                                "bootstrapPopper": "ThemedTooltip-bootstrapPopper-2",
-                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-3",
+                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-2",
                               }
                             }
                             disabled={true}
@@ -2036,26 +1867,11 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
-                              PopperProps={
-                                Object {
-                                  "popperOptions": Object {
-                                    "modifiers": Object {
-                                      "arrow": Object {
-                                        "element": null,
-                                        "enabled": false,
-                                      },
-                                    },
-                                  },
-                                }
-                              }
+                              arrow={true}
                               classes={
                                 Object {
-                                  "popper": "ThemedTooltip-bootstrapPopper-2",
-                                  "tooltip": "ThemedTooltip-bootstrapTooltip-3",
-                                  "tooltipPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                  "tooltipPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                  "tooltipPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                  "tooltipPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
+                                  "arrow": "ThemedTooltip-arrow-1",
+                                  "tooltip": "ThemedTooltip-bootstrapTooltip-2",
                                 }
                               }
                               disableFocusListener={true}
@@ -2064,7 +1880,44 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               enterDelay={400}
                               leaveDelay={200}
                               title={
-                                <UNDEFINED>
+                                <span
+                                  style={
+                                    Object {
+                                      "fontSize": "100%",
+                                    }
+                                  }
+                                >
+                                  <span
+                                    className=""
+                                  >
+                                    w1
+                                  </span>
+                                </span>
+                              }
+                            >
+                              <ForwardRef(Tooltip)
+                                arrow={true}
+                                classes={
+                                  Object {
+                                    "arrow": "MuiTooltip-arrow ThemedTooltip-arrow-1",
+                                    "popper": "MuiTooltip-popper",
+                                    "popperArrow": "MuiTooltip-popperArrow",
+                                    "popperInteractive": "MuiTooltip-popperInteractive",
+                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-2",
+                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
+                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
+                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
+                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
+                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop",
+                                    "touch": "MuiTooltip-touch",
+                                  }
+                                }
+                                disableFocusListener={true}
+                                disableHoverListener={true}
+                                disableTouchListener={true}
+                                enterDelay={400}
+                                leaveDelay={200}
+                                title={
                                   <span
                                     style={
                                       Object {
@@ -2078,64 +1931,6 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       w1
                                     </span>
                                   </span>
-                                  <span
-                                    className="ThemedTooltip-arrow-1"
-                                  />
-                                </UNDEFINED>
-                              }
-                            >
-                              <ForwardRef(Tooltip)
-                                PopperProps={
-                                  Object {
-                                    "popperOptions": Object {
-                                      "modifiers": Object {
-                                        "arrow": Object {
-                                          "element": null,
-                                          "enabled": false,
-                                        },
-                                      },
-                                    },
-                                  }
-                                }
-                                classes={
-                                  Object {
-                                    "arrow": "MuiTooltip-arrow",
-                                    "popper": "MuiTooltip-popper ThemedTooltip-bootstrapPopper-2",
-                                    "popperArrow": "MuiTooltip-popperArrow",
-                                    "popperInteractive": "MuiTooltip-popperInteractive",
-                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-3",
-                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
-                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom ThemedTooltip-bootstrapPlacementBottom-7",
-                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft ThemedTooltip-bootstrapPlacementLeft-4",
-                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight ThemedTooltip-bootstrapPlacementRight-5",
-                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop ThemedTooltip-bootstrapPlacementTop-6",
-                                    "touch": "MuiTooltip-touch",
-                                  }
-                                }
-                                disableFocusListener={true}
-                                disableHoverListener={true}
-                                disableTouchListener={true}
-                                enterDelay={400}
-                                leaveDelay={200}
-                                title={
-                                  <UNDEFINED>
-                                    <span
-                                      style={
-                                        Object {
-                                          "fontSize": "100%",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className=""
-                                      >
-                                        w1
-                                      </span>
-                                    </span>
-                                    <span
-                                      className="ThemedTooltip-arrow-1"
-                                    />
-                                  </UNDEFINED>
                                 }
                               >
                                 <div
@@ -2216,7 +2011,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       </div>
                                     </div>
                                   }
-                                  className="MuiTooltip-popper ThemedTooltip-bootstrapPopper-2"
+                                  className="MuiTooltip-popper MuiTooltip-popperArrow"
                                   id={null}
                                   open={false}
                                   placement="bottom"
@@ -2324,12 +2119,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             classes={
                               Object {
                                 "arrow": "ThemedTooltip-arrow-1",
-                                "bootstrapPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                "bootstrapPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                "bootstrapPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                "bootstrapPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
-                                "bootstrapPopper": "ThemedTooltip-bootstrapPopper-2",
-                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-3",
+                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-2",
                               }
                             }
                             disabled={true}
@@ -2338,26 +2128,11 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
-                              PopperProps={
-                                Object {
-                                  "popperOptions": Object {
-                                    "modifiers": Object {
-                                      "arrow": Object {
-                                        "element": null,
-                                        "enabled": false,
-                                      },
-                                    },
-                                  },
-                                }
-                              }
+                              arrow={true}
                               classes={
                                 Object {
-                                  "popper": "ThemedTooltip-bootstrapPopper-2",
-                                  "tooltip": "ThemedTooltip-bootstrapTooltip-3",
-                                  "tooltipPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                  "tooltipPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                  "tooltipPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                  "tooltipPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
+                                  "arrow": "ThemedTooltip-arrow-1",
+                                  "tooltip": "ThemedTooltip-bootstrapTooltip-2",
                                 }
                               }
                               disableFocusListener={true}
@@ -2366,7 +2141,44 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               enterDelay={400}
                               leaveDelay={200}
                               title={
-                                <UNDEFINED>
+                                <span
+                                  style={
+                                    Object {
+                                      "fontSize": "100%",
+                                    }
+                                  }
+                                >
+                                  <span
+                                    className=""
+                                  >
+                                    w2
+                                  </span>
+                                </span>
+                              }
+                            >
+                              <ForwardRef(Tooltip)
+                                arrow={true}
+                                classes={
+                                  Object {
+                                    "arrow": "MuiTooltip-arrow ThemedTooltip-arrow-1",
+                                    "popper": "MuiTooltip-popper",
+                                    "popperArrow": "MuiTooltip-popperArrow",
+                                    "popperInteractive": "MuiTooltip-popperInteractive",
+                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-2",
+                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
+                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
+                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
+                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
+                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop",
+                                    "touch": "MuiTooltip-touch",
+                                  }
+                                }
+                                disableFocusListener={true}
+                                disableHoverListener={true}
+                                disableTouchListener={true}
+                                enterDelay={400}
+                                leaveDelay={200}
+                                title={
                                   <span
                                     style={
                                       Object {
@@ -2380,64 +2192,6 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       w2
                                     </span>
                                   </span>
-                                  <span
-                                    className="ThemedTooltip-arrow-1"
-                                  />
-                                </UNDEFINED>
-                              }
-                            >
-                              <ForwardRef(Tooltip)
-                                PopperProps={
-                                  Object {
-                                    "popperOptions": Object {
-                                      "modifiers": Object {
-                                        "arrow": Object {
-                                          "element": null,
-                                          "enabled": false,
-                                        },
-                                      },
-                                    },
-                                  }
-                                }
-                                classes={
-                                  Object {
-                                    "arrow": "MuiTooltip-arrow",
-                                    "popper": "MuiTooltip-popper ThemedTooltip-bootstrapPopper-2",
-                                    "popperArrow": "MuiTooltip-popperArrow",
-                                    "popperInteractive": "MuiTooltip-popperInteractive",
-                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-3",
-                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
-                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom ThemedTooltip-bootstrapPlacementBottom-7",
-                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft ThemedTooltip-bootstrapPlacementLeft-4",
-                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight ThemedTooltip-bootstrapPlacementRight-5",
-                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop ThemedTooltip-bootstrapPlacementTop-6",
-                                    "touch": "MuiTooltip-touch",
-                                  }
-                                }
-                                disableFocusListener={true}
-                                disableHoverListener={true}
-                                disableTouchListener={true}
-                                enterDelay={400}
-                                leaveDelay={200}
-                                title={
-                                  <UNDEFINED>
-                                    <span
-                                      style={
-                                        Object {
-                                          "fontSize": "100%",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className=""
-                                      >
-                                        w2
-                                      </span>
-                                    </span>
-                                    <span
-                                      className="ThemedTooltip-arrow-1"
-                                    />
-                                  </UNDEFINED>
                                 }
                               >
                                 <div
@@ -2535,7 +2289,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       </div>
                                     </div>
                                   }
-                                  className="MuiTooltip-popper ThemedTooltip-bootstrapPopper-2"
+                                  className="MuiTooltip-popper MuiTooltip-popperArrow"
                                   id={null}
                                   open={false}
                                   placement="bottom"
@@ -2643,12 +2397,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             classes={
                               Object {
                                 "arrow": "ThemedTooltip-arrow-1",
-                                "bootstrapPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                "bootstrapPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                "bootstrapPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                "bootstrapPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
-                                "bootstrapPopper": "ThemedTooltip-bootstrapPopper-2",
-                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-3",
+                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-2",
                               }
                             }
                             disabled={true}
@@ -2657,26 +2406,11 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
-                              PopperProps={
-                                Object {
-                                  "popperOptions": Object {
-                                    "modifiers": Object {
-                                      "arrow": Object {
-                                        "element": null,
-                                        "enabled": false,
-                                      },
-                                    },
-                                  },
-                                }
-                              }
+                              arrow={true}
                               classes={
                                 Object {
-                                  "popper": "ThemedTooltip-bootstrapPopper-2",
-                                  "tooltip": "ThemedTooltip-bootstrapTooltip-3",
-                                  "tooltipPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                  "tooltipPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                  "tooltipPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                  "tooltipPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
+                                  "arrow": "ThemedTooltip-arrow-1",
+                                  "tooltip": "ThemedTooltip-bootstrapTooltip-2",
                                 }
                               }
                               disableFocusListener={true}
@@ -2685,7 +2419,44 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               enterDelay={400}
                               leaveDelay={200}
                               title={
-                                <UNDEFINED>
+                                <span
+                                  style={
+                                    Object {
+                                      "fontSize": "100%",
+                                    }
+                                  }
+                                >
+                                  <span
+                                    className=""
+                                  >
+                                    w2
+                                  </span>
+                                </span>
+                              }
+                            >
+                              <ForwardRef(Tooltip)
+                                arrow={true}
+                                classes={
+                                  Object {
+                                    "arrow": "MuiTooltip-arrow ThemedTooltip-arrow-1",
+                                    "popper": "MuiTooltip-popper",
+                                    "popperArrow": "MuiTooltip-popperArrow",
+                                    "popperInteractive": "MuiTooltip-popperInteractive",
+                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-2",
+                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
+                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
+                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
+                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
+                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop",
+                                    "touch": "MuiTooltip-touch",
+                                  }
+                                }
+                                disableFocusListener={true}
+                                disableHoverListener={true}
+                                disableTouchListener={true}
+                                enterDelay={400}
+                                leaveDelay={200}
+                                title={
                                   <span
                                     style={
                                       Object {
@@ -2699,64 +2470,6 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       w2
                                     </span>
                                   </span>
-                                  <span
-                                    className="ThemedTooltip-arrow-1"
-                                  />
-                                </UNDEFINED>
-                              }
-                            >
-                              <ForwardRef(Tooltip)
-                                PopperProps={
-                                  Object {
-                                    "popperOptions": Object {
-                                      "modifiers": Object {
-                                        "arrow": Object {
-                                          "element": null,
-                                          "enabled": false,
-                                        },
-                                      },
-                                    },
-                                  }
-                                }
-                                classes={
-                                  Object {
-                                    "arrow": "MuiTooltip-arrow",
-                                    "popper": "MuiTooltip-popper ThemedTooltip-bootstrapPopper-2",
-                                    "popperArrow": "MuiTooltip-popperArrow",
-                                    "popperInteractive": "MuiTooltip-popperInteractive",
-                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-3",
-                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
-                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom ThemedTooltip-bootstrapPlacementBottom-7",
-                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft ThemedTooltip-bootstrapPlacementLeft-4",
-                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight ThemedTooltip-bootstrapPlacementRight-5",
-                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop ThemedTooltip-bootstrapPlacementTop-6",
-                                    "touch": "MuiTooltip-touch",
-                                  }
-                                }
-                                disableFocusListener={true}
-                                disableHoverListener={true}
-                                disableTouchListener={true}
-                                enterDelay={400}
-                                leaveDelay={200}
-                                title={
-                                  <UNDEFINED>
-                                    <span
-                                      style={
-                                        Object {
-                                          "fontSize": "100%",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className=""
-                                      >
-                                        w2
-                                      </span>
-                                    </span>
-                                    <span
-                                      className="ThemedTooltip-arrow-1"
-                                    />
-                                  </UNDEFINED>
                                 }
                               >
                                 <div
@@ -2854,7 +2567,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       </div>
                                     </div>
                                   }
-                                  className="MuiTooltip-popper ThemedTooltip-bootstrapPopper-2"
+                                  className="MuiTooltip-popper MuiTooltip-popperArrow"
                                   id={null}
                                   open={false}
                                   placement="bottom"
@@ -2962,12 +2675,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             classes={
                               Object {
                                 "arrow": "ThemedTooltip-arrow-1",
-                                "bootstrapPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                "bootstrapPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                "bootstrapPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                "bootstrapPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
-                                "bootstrapPopper": "ThemedTooltip-bootstrapPopper-2",
-                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-3",
+                                "bootstrapTooltip": "ThemedTooltip-bootstrapTooltip-2",
                               }
                             }
                             disabled={true}
@@ -2976,26 +2684,11 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                             targetLanguageFontClassName=""
                           >
                             <WithStyles(ForwardRef(Tooltip))
-                              PopperProps={
-                                Object {
-                                  "popperOptions": Object {
-                                    "modifiers": Object {
-                                      "arrow": Object {
-                                        "element": null,
-                                        "enabled": false,
-                                      },
-                                    },
-                                  },
-                                }
-                              }
+                              arrow={true}
                               classes={
                                 Object {
-                                  "popper": "ThemedTooltip-bootstrapPopper-2",
-                                  "tooltip": "ThemedTooltip-bootstrapTooltip-3",
-                                  "tooltipPlacementBottom": "ThemedTooltip-bootstrapPlacementBottom-7",
-                                  "tooltipPlacementLeft": "ThemedTooltip-bootstrapPlacementLeft-4",
-                                  "tooltipPlacementRight": "ThemedTooltip-bootstrapPlacementRight-5",
-                                  "tooltipPlacementTop": "ThemedTooltip-bootstrapPlacementTop-6",
+                                  "arrow": "ThemedTooltip-arrow-1",
+                                  "tooltip": "ThemedTooltip-bootstrapTooltip-2",
                                 }
                               }
                               disableFocusListener={true}
@@ -3004,7 +2697,44 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                               enterDelay={400}
                               leaveDelay={200}
                               title={
-                                <UNDEFINED>
+                                <span
+                                  style={
+                                    Object {
+                                      "fontSize": "100%",
+                                    }
+                                  }
+                                >
+                                  <span
+                                    className=""
+                                  >
+                                    w3
+                                  </span>
+                                </span>
+                              }
+                            >
+                              <ForwardRef(Tooltip)
+                                arrow={true}
+                                classes={
+                                  Object {
+                                    "arrow": "MuiTooltip-arrow ThemedTooltip-arrow-1",
+                                    "popper": "MuiTooltip-popper",
+                                    "popperArrow": "MuiTooltip-popperArrow",
+                                    "popperInteractive": "MuiTooltip-popperInteractive",
+                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-2",
+                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
+                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom",
+                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft",
+                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight",
+                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop",
+                                    "touch": "MuiTooltip-touch",
+                                  }
+                                }
+                                disableFocusListener={true}
+                                disableHoverListener={true}
+                                disableTouchListener={true}
+                                enterDelay={400}
+                                leaveDelay={200}
+                                title={
                                   <span
                                     style={
                                       Object {
@@ -3018,64 +2748,6 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       w3
                                     </span>
                                   </span>
-                                  <span
-                                    className="ThemedTooltip-arrow-1"
-                                  />
-                                </UNDEFINED>
-                              }
-                            >
-                              <ForwardRef(Tooltip)
-                                PopperProps={
-                                  Object {
-                                    "popperOptions": Object {
-                                      "modifiers": Object {
-                                        "arrow": Object {
-                                          "element": null,
-                                          "enabled": false,
-                                        },
-                                      },
-                                    },
-                                  }
-                                }
-                                classes={
-                                  Object {
-                                    "arrow": "MuiTooltip-arrow",
-                                    "popper": "MuiTooltip-popper ThemedTooltip-bootstrapPopper-2",
-                                    "popperArrow": "MuiTooltip-popperArrow",
-                                    "popperInteractive": "MuiTooltip-popperInteractive",
-                                    "tooltip": "MuiTooltip-tooltip ThemedTooltip-bootstrapTooltip-3",
-                                    "tooltipArrow": "MuiTooltip-tooltipArrow",
-                                    "tooltipPlacementBottom": "MuiTooltip-tooltipPlacementBottom ThemedTooltip-bootstrapPlacementBottom-7",
-                                    "tooltipPlacementLeft": "MuiTooltip-tooltipPlacementLeft ThemedTooltip-bootstrapPlacementLeft-4",
-                                    "tooltipPlacementRight": "MuiTooltip-tooltipPlacementRight ThemedTooltip-bootstrapPlacementRight-5",
-                                    "tooltipPlacementTop": "MuiTooltip-tooltipPlacementTop ThemedTooltip-bootstrapPlacementTop-6",
-                                    "touch": "MuiTooltip-touch",
-                                  }
-                                }
-                                disableFocusListener={true}
-                                disableHoverListener={true}
-                                disableTouchListener={true}
-                                enterDelay={400}
-                                leaveDelay={200}
-                                title={
-                                  <UNDEFINED>
-                                    <span
-                                      style={
-                                        Object {
-                                          "fontSize": "100%",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className=""
-                                      >
-                                        w3
-                                      </span>
-                                    </span>
-                                    <span
-                                      className="ThemedTooltip-arrow-1"
-                                    />
-                                  </UNDEFINED>
                                 }
                               >
                                 <div
@@ -3157,7 +2829,7 @@ exports[`Test DroppableWordList component in WordList/index.js DroppableWordList
                                       </div>
                                     </div>
                                   }
-                                  className="MuiTooltip-popper ThemedTooltip-bootstrapPopper-2"
+                                  className="MuiTooltip-popper MuiTooltip-popperArrow"
                                   id={null}
                                   open={false}
                                   placement="bottom"


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- fix arrow on word bank item hover

#### Please include detailed Test instructions for your pull request:
- test with tC branch `bugfix-mcleanb-7034`
- in wA, test hover text in group menu when selection text overflows - arrow should not move
- in wA, test hover text in word bank when word overflows - arrow should not move

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Check that there are not inadvertent commits to tC Apps when reviewing a tC Core PR
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
- [ ] Ask Ben or Koz if you have any concerns about implementation (especially UI related)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/wordalignment/294)
<!-- Reviewable:end -->
