### PR TITLE
Feature 7171/Add verse span support to WA

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -47,6 +47,7 @@ import {
 } from './state/actions/contextIdActions';
 import SimpleCache, { INSTANCE_STORAGE } from './utils/SimpleCache';
 import { migrateChapterAlignments } from './utils/migrations';
+import { isValidVerse } from './utils/alignmentValidation';
 // consts
 import {
   FINISHED_KEY,
@@ -132,7 +133,7 @@ export default class Api extends ToolApi {
     } = props;
 
     for (const verse of Object.keys(targetBook[chapter])) {
-      if (!isNaN(verse)) { // only load valid numbers
+      if (isValidVerse(verse)) { // only load valid verse ids
         if (sourceBook[chapter][verse] === undefined) {
           console.warn(
             `Missing passage ${chapter}:${verse} in source text. Skipping alignment initialization.`);
@@ -191,7 +192,7 @@ export default class Api extends ToolApi {
    * @param {boolean} silent - if true, alignments invalidated prompt is not displayed, only valid returned
    */
   validateVerse(chapter, verse, silent=false) {
-    if (isNaN(verse) || parseInt(verse) === -1 ||
+    if (!isValidVerse(verse) ||
       isNaN(chapter) || parseInt(chapter) === -1) {
       return;
     }
@@ -350,8 +351,7 @@ export default class Api extends ToolApi {
 
     const verses = Object.keys(targetBook[chapter]).sort(verseComparator);
     for (const verse of verses) {
-      const verseNum = parseInt(verse);
-      if (isNaN(verseNum) || verseNum < 0) {
+      if (!isValidVerse(verse)) {
         continue;
       }
       loadGroupMenuItem(this, chapter, verse, contextId);
@@ -804,7 +804,7 @@ export default class Api extends ToolApi {
       for (let j = 0, verseLen = verses.length; j < verseLen; j ++) {
         const verse = verses[j];
 
-        if (isNaN(verse) || parseInt(verse) === -1) {
+        if (!isValidVerse(verse)) {
           continue;
         }
 
@@ -849,7 +849,7 @@ export default class Api extends ToolApi {
       for (let j = 0, verseLen = verses.length; j < verseLen; j ++) {
         const verse = verses[j];
 
-        if (isNaN(verse) || parseInt(verse) === -1) {
+        if (!isValidVerse(verse)) {
           continue;
         }
 

--- a/src/Api.js
+++ b/src/Api.js
@@ -40,6 +40,7 @@ import {
   repairAndInspectVerse,
   resetVerse,
   unalignTargetToken,
+  verseComparator,
 } from './state/actions';
 import {
   clearContextId,
@@ -347,8 +348,10 @@ export default class Api extends ToolApi {
       return true;
     }
 
-    for (const verse of Object.keys(targetBook[chapter])) {
-      if (isNaN(verse) || parseInt(verse) === -1) {
+    const verses = Object.keys(targetBook[chapter]).sort(verseComparator);
+    for (const verse of verses) {
+      const verseNum = parseInt(verse);
+      if (isNaN(verseNum) || verseNum < 0) {
         continue;
       }
       loadGroupMenuItem(this, chapter, verse, contextId);

--- a/src/components/AlignmentCard/index.js
+++ b/src/components/AlignmentCard/index.js
@@ -182,7 +182,7 @@ class DroppableAlignmentCard extends Component {
 }
 
 DroppableAlignmentCard.propTypes = {
-  fontSize: PropTypes.string,
+  fontSize: PropTypes.number,
   onCancelTokenSuggestion: PropTypes.func,
   onAcceptTokenSuggestion: PropTypes.func,
   translate: PropTypes.func.isRequired,

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -109,7 +109,7 @@ const styles = {
  * @param targetBook
  * @param state
  * @param {number} currentChapter
- * @param {number} currentVerse
+ * @param {number|string} currentVerse
  * @return {Promise<WordMap>}
  */
 export const generateMAP = (
@@ -122,7 +122,7 @@ export const generateMAP = (
       const chapterAlignments = getChapterAlignments(state, chapter);
 
       for (const verse of Object.keys(chapterAlignments)) {
-        if (parseInt(verse) === currentVerse && parseInt(chapter) ===
+        if (verse === currentVerse && parseInt(chapter) ===
             currentChapter) {
           // exclude current verse from saved alignments
           continue;

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -98,7 +98,7 @@ const styles = {
     display: 'flex',
     flexDirection: 'column',
     flex: '1 1 auto',
-    overflowY: 'auto',
+    overflow: 'auto',
     boxSizing: 'border-box',
     margin: '0 10px 6px 10px',
     boxShadow: '0 3px 10px var(--background-color)',

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -97,7 +97,8 @@ const styles = {
   alignmentGridWrapper: {
     display: 'flex',
     flexDirection: 'column',
-    height: '100%',
+    flex: '1 1 auto',
+    overflowY: 'auto',
     boxSizing: 'border-box',
     margin: '0 10px 6px 10px',
     boxShadow: '0 3px 10px var(--background-color)',

--- a/src/components/PrimaryToken.js
+++ b/src/components/PrimaryToken.js
@@ -121,7 +121,7 @@ class PrimaryToken extends Component {
 }
 
 PrimaryToken.propTypes = {
-  fontSize: PropTypes.string,
+  fontSize: PropTypes.number,
   translate: PropTypes.func.isRequired,
   wordIndex: PropTypes.number,
   alignmentLength: PropTypes.number,

--- a/src/components/WordCard/WordOccurrence.js
+++ b/src/components/WordCard/WordOccurrence.js
@@ -65,7 +65,7 @@ const WordOccurrence = ({
 WordOccurrence.propTypes = {
   style: PropTypes.object,
   isHebrew: PropTypes.bool,
-  fontSize: PropTypes.string,
+  fontSize: PropTypes.number,
   occurrence: PropTypes.number.isRequired,
   occurrences: PropTypes.number.isRequired,
 };

--- a/src/components/WordCard/index.js
+++ b/src/components/WordCard/index.js
@@ -191,7 +191,7 @@ class WordCard extends React.Component {
 
 WordCard.propTypes = {
   isHebrew: PropTypes.bool,
-  fontSize: PropTypes.string,
+  fontSize: PropTypes.number,
   disableTooltip: PropTypes.bool,
   selected: PropTypes.bool,
   disabled: PropTypes.bool,

--- a/src/components/WordList/index.js
+++ b/src/components/WordList/index.js
@@ -162,7 +162,7 @@ class DroppableWordList extends React.Component {
 
 DroppableWordList.propTypes = {
   reset: PropTypes.bool,
-  verse: PropTypes.number,
+  verse: PropTypes.oneOf(PropTypes.number, PropTypes.string),
   chapter: PropTypes.number,
   wordList: PropTypes.object,
   isOver: PropTypes.bool.isRequired,

--- a/src/state/actions/__tests__/actions.noMock.test.js
+++ b/src/state/actions/__tests__/actions.noMock.test.js
@@ -1,0 +1,63 @@
+import {getVerseSpanRange, verseComparator} from "../index";
+
+describe('verseComparator', () => {
+  it('sorting verse order', () => {
+    //given
+    const chapter = '1';
+    const verses = ['before', '4', '3', '1-2' ];
+    const currentBible = createChapterWithVerses(chapter, verses);
+    const expectedVerseOrder = ['1-2', '3', '4', 'before'];
+
+    //when
+    const sortedVerses = Object.keys(currentBible[chapter]).sort(verseComparator);
+
+    //then
+    expect(sortedVerses).toEqual(expectedVerseOrder);
+  });
+});
+
+describe('getVerseSpanRange', () => {
+  it('should succeed', () => {
+    //given
+    const verses = '1-2';
+    const expectedResult = {
+      low: 1,
+      high: 2,
+    };
+
+    //when
+    const verseSpan = getVerseSpanRange(verses);
+
+    //then
+    expect(verseSpan).toEqual(expectedResult);
+  });
+});
+
+//
+// Helper functions
+//
+
+/**
+ * create dummy content for verse
+ * @param {string} verse
+ * @return {string}
+ */
+function createVerseContent(verse) {
+  return `${verse}-Content`;
+}
+
+/**
+ * create dummy Bible with given chapter and verses
+ * @param {string} chapter
+ * @param {array} verses
+ * @return {object}
+ */
+function createChapterWithVerses(chapter, verses) {
+  const chapterData = {};
+
+  for (let verse of verses) {
+    chapterData[verse] = createVerseContent(verse);
+  }
+
+  return { [chapter]: chapterData };
+}

--- a/src/state/actions/__tests__/actions.noMock.test.js
+++ b/src/state/actions/__tests__/actions.noMock.test.js
@@ -1,4 +1,4 @@
-import {getVerseSpanRange, verseComparator} from "../index";
+import { getVerseSpanRange, verseComparator } from '../index';
 
 describe('verseComparator', () => {
   it('sorting verse order', () => {

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -1,4 +1,5 @@
 import Lexer from 'wordmap-lexer';
+import {verseHelpers} from 'tc-ui-toolkit';
 import {migrateChapterAlignments} from '../../utils/migrations';
 import {tokenizeVerseObjects} from '../../utils/verseObjects';
 import {removeUsfmMarkers} from '../../utils/usfmHelpers';
@@ -119,7 +120,7 @@ export const indexChapterAlignments = (
             const verseData = sourceChapter[verseStr];
             if (verseData) {
               if (combined.length) {
-                combined = combined.concat({type: 'text', text: `\n  ${chapterId}:${i} `});
+                combined.push(verseHelpers.createVerseMarker(i));
               }
               combined = combined.concat(verseData.verseObjects);
             }

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -97,6 +97,7 @@ export const indexChapterAlignments = (
     }
     for (const verseSpan of verseSpans) {
       if (!sourceChapter[verseSpan]) {
+        // if verse span and verse span does not exist, create span by combining verses
         let combined = [];
         const { low, high } = getVerseSpanRange(verseSpan);
         if ((low > 0) && (high > 0)) {
@@ -104,7 +105,7 @@ export const indexChapterAlignments = (
             const verseStr = i.toString();
             const verseData = sourceChapter[verseStr];
             if (verseData) {
-              if (combined.length) {
+              if (combined.length) { // add verse marker between each verse
                 combined.push(verseHelpers.createVerseMarker(i));
               }
               combined = combined.concat(verseData.verseObjects);

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -97,10 +97,10 @@ export const indexChapterAlignments = (
       sourceChapterTokens[verse] = tokenizeVerseObjects(
         sourceChapter[verse].verseObjects);
     }
-    for (const verse of verseSpans) {
-      if (!sourceChapter[verse]) {
+    for (const verseSpan of verseSpans) {
+      if (!sourceChapter[verseSpan]) {
         let combined = [];
-        let [low, high] = verse.split('-');
+        let [low, high] = verseSpan.split('-');
         low = parseInt(low)
         high = parseInt(high)
         for (let i = low; i <= high; i++) {
@@ -113,11 +113,11 @@ export const indexChapterAlignments = (
             combined = combined.concat(verseData.verseObjects)
           }
           // remove individual verses after merging into verse span
-          delete sourceChapter[verseStr];
-          delete sourceChapterTokens[verseStr];
+          delete targetChapter[verseStr];
+          delete targetChapterTokens[verseStr];
         }
-        sourceChapter[verse] = {verseObjects: combined};
-        sourceChapterTokens[verse] = tokenizeVerseObjects(combined);
+        sourceChapter[verseSpan] = {verseObjects: combined};
+        sourceChapterTokens[verseSpan] = tokenizeVerseObjects(combined);
       }
     }
 

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -35,7 +35,7 @@ export const resetVerse = (chapter, verse, sourceTokens, targetTokens) => {
 };
 
 /**
- * convert verse to number
+ * convert verse to number for sorting
  * @param a
  * @return {number}
  */
@@ -52,21 +52,6 @@ export const verseComparator = (a, b) => {
   const diff = getNumber(a) - getNumber(b);
   return diff;
 };
-
-/**
- * returns new object with keys are sorted by verse order
- * @param object
- * @return {*[]} new sorted object
- */
-export const sortObjectByVerse = (object) => {
-  let keys = Object.keys(object);
-  keys = keys.sort(verseComparator);
-  const newObject = [];
-  for (let key of keys) {
-    newObject[key] = object[key];
-  }
-  return newObject;
-}
 
 /**
  * get verse range from span
@@ -132,14 +117,6 @@ export const indexChapterAlignments = (
         sourceChapter[verseSpan] = { verseObjects: combined };
         sourceChapterTokens[verseSpan] = tokenizeVerseObjects(combined);
       }
-    }
-
-    if (verseSpans.length) {
-      // fixup verse order
-      sourceChapter = sortObjectByVerse(sourceChapter);
-      sourceChapterTokens = sortObjectByVerse(sourceChapterTokens);
-      targetChapter = sortObjectByVerse(targetChapter);
-      targetChapterTokens = sortObjectByVerse(targetChapterTokens);
     }
 
     // migrate alignment data

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -116,7 +116,7 @@ export const indexChapterAlignments = (
           delete sourceChapter[verseStr];
           delete sourceChapterTokens[verseStr];
         }
-        sourceChapter[verse] = combined;
+        sourceChapter[verse] = {verseObjects: combined};
         sourceChapterTokens[verse] = tokenizeVerseObjects(combined);
       }
     }

--- a/src/state/actions/verseEditActions.js
+++ b/src/state/actions/verseEditActions.js
@@ -206,7 +206,7 @@ export const recordTargetVerseEdit = (bookId, chapter, verse, before, after, tag
   reference: {
     bookId,
     chapter: parseInt(chapter),
-    verse: parseInt(verse),
+    verse: verse,
     groupId,
   },
   quote,

--- a/src/state/actions/verseEditActions.js
+++ b/src/state/actions/verseEditActions.js
@@ -41,7 +41,6 @@ export const editTargetVerse = (chapterWithVerseEdit, verseWithVerseEdit, before
   const {
     bookId, chapter: currentCheckChapter, verse: currentCheckVerse,
   } = currentCheckContextId.reference;
-  verseWithVerseEdit = (typeof verseWithVerseEdit === 'string') ? parseInt(verseWithVerseEdit) : verseWithVerseEdit; // make sure number
 
   const contextIdWithVerseEdit = {
     ...currentCheckContextId,

--- a/src/state/reducers/alignments/chapter.js
+++ b/src/state/reducers/alignments/chapter.js
@@ -39,8 +39,8 @@ const chapter = (state = {}, action) => {
     case SET_ALIGNMENT_SUGGESTIONS:
     case RESET_VERSE_ALIGNMENTS:
     case ALIGN_RENDERED_TARGET_TOKEN: {
-      if(isNaN(action.verse)) {
-        throw new Error('Alignment verse must be a number');
+      if(isNaN(action.verse) && (!action.verse.includes('-'))) {
+        throw new Error(`Alignment verse must be a number or span, not ${action.verse}`);
       }
       const vid = action.verse + '';
       return {

--- a/src/state/reducers/alignments/chapter.js
+++ b/src/state/reducers/alignments/chapter.js
@@ -16,6 +16,7 @@ import {
   UNALIGN_RENDERED_TARGET_TOKEN
 } from '../../actions/actionTypes';
 import verse, * as fromVerse from './verse';
+import { isValidVerse } from '../../../utils/alignmentValidation';
 
 /**
  * Reduces the chapter alignment state
@@ -39,7 +40,7 @@ const chapter = (state = {}, action) => {
     case SET_ALIGNMENT_SUGGESTIONS:
     case RESET_VERSE_ALIGNMENTS:
     case ALIGN_RENDERED_TARGET_TOKEN: {
-      if(isNaN(action.verse) && (!action.verse.includes('-'))) {
+      if(!isValidVerse(action.verse)) {
         throw new Error(`Alignment verse must be a number or span, not ${action.verse}`);
       }
       const vid = action.verse + '';

--- a/src/state/reducers/alignments/index.js
+++ b/src/state/reducers/alignments/index.js
@@ -89,7 +89,7 @@ export const getChapterAlignments = (state, chapter) => {
     const alignments = {};
     for (const verseId of Object.keys(state[chapterId])) {
       alignments[verseId] = getVerseAlignments(state, chapter,
-        parseInt(verseId));
+        verseId);
     }
     return alignments;
   } else {

--- a/src/state/reducers/alignments/index.js
+++ b/src/state/reducers/alignments/index.js
@@ -88,8 +88,7 @@ export const getChapterAlignments = (state, chapter) => {
   if (chapterId in state) {
     const alignments = {};
     for (const verseId of Object.keys(state[chapterId])) {
-      alignments[verseId] = getVerseAlignments(state, chapter,
-        verseId);
+      alignments[verseId] = getVerseAlignments(state, chapter, verseId);
     }
     return alignments;
   } else {

--- a/src/utils/__tests__/alignmentValidation.test.js
+++ b/src/utils/__tests__/alignmentValidation.test.js
@@ -1,4 +1,54 @@
-import {areAlignmentsEquivalent} from '../alignmentValidation';
+import {areAlignmentsEquivalent, isValidVerse} from '../alignmentValidation';
+
+describe('isValidVerse', () => {
+  it('number is valid', () => {
+    //given
+    const verse = 1;
+    const expected = true;
+
+    // when
+    const isValid = isValidVerse(verse);
+
+    //then
+    expect(isValid).toEqual(expected);
+  });
+
+  it('number string is valid', () => {
+    //given
+    const verse = '1';
+    const expected = true;
+
+    // when
+    const isValid = isValidVerse(verse);
+
+    //then
+    expect(isValid).toEqual(expected);
+  });
+
+  it('number span is valid', () => {
+    //given
+    const verse = '1-2';
+    const expected = true;
+
+    // when
+    const isValid = isValidVerse(verse);
+
+    //then
+    expect(isValid).toEqual(expected);
+  });
+
+  it('non-numeric string is not valid', () => {
+    //given
+    const verse = 'front';
+    const expected = false;
+
+    // when
+    const isValid = isValidVerse(verse);
+
+    //then
+    expect(isValid).toEqual(expected);
+  });
+});
 
 describe('Determine alignment equivalence', () => {
 

--- a/src/utils/alignmentValidation.js
+++ b/src/utils/alignmentValidation.js
@@ -74,7 +74,7 @@ export function isValidVerse(verse) {
       return !isNaN(verse);
     case 'string':
       const value = parseInt(verse); // this will work for verse spans and verse numbers as strings
-      return value !== -1;
+      return !isNaN(value);
     default:
       break;
   }

--- a/src/utils/alignmentValidation.js
+++ b/src/utils/alignmentValidation.js
@@ -61,3 +61,22 @@ function compareTokens(prev, next) {
   // TRICKY: this is in a separate function just in case we need additional logic.
   return prev.text === next.text;
 }
+
+/**
+ * test if verse is valid verse number or verse span string
+ * @param {string|number} verse
+ * @return {boolean}
+ */
+export function isValidVerse(verse) {
+  const type = typeof verse;
+  switch (type) {
+    case 'number':
+      return !isNaN(verse);
+    case 'string':
+      const value = parseInt(verse); // this will work for verse spans and verse numbers as strings
+      return value !== -1;
+    default:
+      break;
+  }
+  return false; // anything else is not valid
+}


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- added support for verse spans - removed automatic casting of verses to numbers
- added lookup of verse within verse range.

#### Please include detailed Test instructions for your pull request:
- test with build - https://github.com/unfoldingWord/translationCore/actions/runs/1343725773
- [ ] import a project with a verse span such as https://git.door43.org/lrsallee/en_ust_gal_book.  Take note of the missing verses warnings.  That is likely the verse spans.  Other books with verse spans are (https://git.door43.org/christopherrsmith/en_ust_act_book, https://git.door43.org/lrsallee/en_ust_luk_book, https://git.door43.org/lrsallee/en_ust_jos_book)
- [ ] open WA and navigate to chapter with verse span. (in Gal it is 1:1-2)
- [ ] group menu should show verse spans on left side:

<img width="1433" alt="Screen Shot 2021-10-11 at 7 51 00 AM" src="https://user-images.githubusercontent.com/14238574/136949622-5fb6708a-b75b-49ed-939f-7f803e8cc781.png">

- [ ] select the verse span and look at the Scripture Pane.  The verse bridges should be shown and the panes that do not have verse bridges should display all the verses in the span. (see above)
- [ ] make sure in the alignment grid that all the words for all the verses are included.  align the verse span.  I sped up the process by first clicking the accept button.  Then I would select multiple target words by holding down the shift button and then clicking on several words.  I then would drag these to a greek word.  Then if there are any empty greek words i would drag them to another greek word until the alignment complete toggled on.
- [ ] go back to projects page to exit app.  close tcore and open the project again.  open wa tool and should not see any warnings about alignments invalidated.
- [ ] open Expanded Scripture Pane and should see verse spans in order:

<img width="1319" alt="Screen Shot 2021-10-11 at 8 23 12 AM" src="https://user-images.githubusercontent.com/14238574/136952553-abb680ba-5f3a-40c7-a4e9-492edb7a658d.png">

- [ ] edit verse span changing one of the aligned words.  Should see invalidation warning.  Close expanded scripture pane and should see alignments invalidated icon on verse span.
- [ ] go back to tools page and should see one invalidation
- [ ] open WA tool and mark alignment complete or fix the alignment.  go back to tools page and should see no invalidations.
- [ ] open WA again and make sure comments and bookmarks work.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/wordalignment/308)
<!-- Reviewable:end -->
